### PR TITLE
add version, keywords, doi

### DIFF
--- a/schema/wcmpRecordGeoJSON.yaml
+++ b/schema/wcmpRecordGeoJSON.yaml
@@ -22,6 +22,9 @@ properties:
       - recordUpdated
       - license
     properties:
+      version:
+        type: string
+        description: The version or edition of a given dataset or product.
       associations:
         items:
           $ref: link.yaml

--- a/standard/recommendations/core/PER_doi.adoc
+++ b/standard/recommendations/core/PER_doi.adoc
@@ -1,0 +1,7 @@
+[[per_core_doi]]
+[width="90%",cols="2,6a"]
+|===
+^|*Permission {counter:per-id}* |*/per/core/doi*
+^|A |A WCMP record MAY provide a Digital Object Identifier (DOI) as a means to cite research or
+resource identification using the DOI framework.
+|===

--- a/standard/recommendations/core/PER_version.adoc
+++ b/standard/recommendations/core/PER_version.adoc
@@ -1,0 +1,7 @@
+[[per_core_version]]
+[width="90%",cols="2,6a"]
+|===
+^|*Permission {counter:per-id}* |*/per/core/version*
+^|A |A WCMP record MAY provide a `+properties.version+` property to describe the version
+of a given dataset or product.
+|===

--- a/standard/recommendations/core/REC_doi.adoc
+++ b/standard/recommendations/core/REC_doi.adoc
@@ -1,0 +1,6 @@
+[[rec_core_doi]]
+[width="90%",cols="2,6a"]
+|===
+^|*Recommendation {counter:rec-id}* |*/rec/core/doi*
+^|A |A WCMP record SHOULD provide DOI references via an item in the `+properties.externalIds+` array property, where the value of `+schema+` should be fixed to `+doi+`, and the value of `+value+` should be the full DOI with `+prefix/suffix+` (example `+10.14287/10000001+`).
+|===

--- a/standard/recommendations/core/REC_keywords.adoc
+++ b/standard/recommendations/core/REC_keywords.adoc
@@ -1,0 +1,6 @@
+[[rec_core_keywords]]
+[width="90%",cols="2,6a"]
+|===
+^|*Recommendation {counter:rec-id}* |*/rec/core/keywords*
+^|A |A WCMP record SHOULD provide a `+properties.keywords+` property, as a list of freeform text or tags.
+|===

--- a/standard/sections/clause_6_informative_text.adoc
+++ b/standard/sections/clause_6_informative_text.adoc
@@ -110,7 +110,7 @@ The OGC Records - API - Part 1: Core specification:
 
 === The WIS 2.0 Global Discovery Catalogue
 
-The GDC will provide a central search endpoint, enabling users users to traverse, browse and search
+The GDC will provide a central search endpoint, enabling users to traverse, browse and search
 data holdings in WIS 2.0.  Key search predicate capabilities include:
 
 * spatial

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -50,9 +50,16 @@ include::../requirements/core/REQ_title.adoc[]
 ==== Description
 
 A WCMP record can have a `+properties.description+` property, which is a free-text summary description of the
-resource the provider wishes to make discoverable. TODO: this is now a SHALL
+resource the provider wishes to make discoverable.
 
 include::../requirements/core/REQ_description.adoc[]
+
+==== Keywords
+
+A WCMP record can have has a `+properties.keywords+` property, typically represented using keywords, tags, key
+phrases, or classification codes.
+
+include::../recommendations/core/REC_keywords.adoc[]
 
 ==== Themes and Topic Hierarchy
 
@@ -62,14 +69,28 @@ forth as a specific theme/concept.
 
 include::../requirements/core/REQ_themes_topic_hierarchy.adoc[]
 
-TODO: should we add a RECOMMENDATION for keywords?
-
 ==== Providers
 
 A WCMP record can be one or more providers as part of the `+properties.providers+` property.  These elements
 provide contact information based on the role of the provider.
 
 include::../requirements/core/REQ_providers.adoc[]
+
+=== Version
+
+Datasets can typically be versioned by an organization (version of an NWP model, processing chain/workflow, etc.).  Data
+providers may choose to make this information available to the user when providing multiple versions of a dataset
+over time.
+
+include::../recommendations/core/PER_version.adoc[]
+
+=== Digital Object Identifier
+
+A digital object identifier (DOI) is a persistent identifier or handle used to identify various objects uniquely,
+and is widely in scientific publications.
+
+include::../recommendations/core/PER_doi.adoc[]
+include::../recommendations/core/REC_doi.adoc[]
 
 ==== Record Creation Date
 


### PR DESCRIPTION
This PR provides the following updates:
- adds a `properties.version` property
- describes how to encode DOIs
- confirms `properties.description` as MANDATORY
- adds a recommendation for `properties.keywords`