### PR TITLE
add access control to distribution subclause

### DIFF
--- a/schema/link.yaml
+++ b/schema/link.yaml
@@ -6,6 +6,9 @@ description: WCMP 2 link object definition
 allOf:
   - $ref: https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/schemas/common/link.yaml
 properties:
+  security:
+    type: object
+    $ref: https://raw.githubusercontent.com/OAI/OpenAPI-Specification/3.1.0/schemas/v3.0/schema.yaml#/definitions/Components/securitySchemes
   distribution:
     type: object
     description: the additional information qualifying the service and allowing to build and display the "access" information in a portal

--- a/standard/abstract_tests/core/ATS_test_links.adoc
+++ b/standard/abstract_tests/core/ATS_test_links.adoc
@@ -31,5 +31,11 @@ For a link object describing archived (NOT real-time) data made available via AP
 --
 For a link object describing archived (NOT real-time) data made available via Web Accessible Folder, check that the `+rel+` property is a recognized API service type as defined by IANA or OGC.
 --
+
+[.component,class=step]
+--
+For a link object with access control (defined by the `+security+` object), check that the `+security+` property contains a `+description+` property with instructions on how to obtain access.
+--
+
 =====
 ====

--- a/standard/requirements/core/REQ_links.adoc
+++ b/standard/requirements/core/REQ_links.adoc
@@ -6,4 +6,5 @@
 ^|B |A WCMP record `+links+` property SHALL contain at least one link to the data access service allowing users to download the data in one of the supported formats.
 ^|C |A WCMP record `+links+` property SHALL contain the MQTT topic information for real-time data under which the data publication notifications will accessible from the WIS 2 Global Broker. The topic shall follow the WIS 2 topic hierarchy defined in (TODO add the reference to the topic hierarchy documentation).
 ^|D |A WCMP record `+links+` property SHALL contain a Web Accessible Folder (WAF) OR an API link for non real-time data (e.g. climate records, hydrometric data archives).
+^|E |A WCMP record `+links+` property SHALL contain access control information for data, products and services requiring authentication / authorization.
 |===

--- a/standard/requirements/requirements_class_core.adoc
+++ b/standard/requirements/requirements_class_core.adoc
@@ -8,6 +8,7 @@
 |Dependency |<<json-schema, JSON Schema>>
 |Dependency |<<rfc7946,GeoJSON>>
 |Dependency |<<ogcapi-records,OGC API - Records - Core: Part 1>>
+|Dependency |<<openapi,OpenAPI Specification, Version 3.1.0>>
 |Pre-conditions |
 The record conforms to OGC API - Records - Core: Part 1: Requirements Class: Record Core
 |===

--- a/standard/sections/clause_3_references.adoc
+++ b/standard/sections/clause_3_references.adoc
@@ -11,3 +11,4 @@
 * Linux Foundation: SPDX License List (2021) footnote:[https://spdx.org/licenses]
 * [[json-schema]] IETF: JSON Schema (2022) footnote:[https://json-schema.org]
 * [[wis2-topic-hierarchy]] WMO: WIS2 Topic Hierarchy (2022) footnote:[https://github.com/wmo-im/wis2-topic-hierarchy]
+* [[openapi]] OpenAPI Specification 3.1.0 (2022) footnote:[https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md]

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -588,6 +588,25 @@ Additional distribution information is added to allow creating more comprehensiv
 }
 ----
 
+WCMP record links may also provide links to services which implement access control in support of authentication and authorization.  In
+secure data use cases, a user needs to be able to detect access controlled data as part of data discovery and evaluation.  The
+example demonstrates how to express access control using HTTP Basic Authentication for a given data access service.
+
+[source,json]
+----
+{
+    "rel": "download",
+    "type": "application/json",
+    "title": "link to WAF endpoint",
+    "href": "https://example.org/data/secure-data",
+    "security": {
+      "type": "http",
+      "scheme": "basic",
+      "description": "please contact the data provider for accessing this secured resource"
+    }
+}
+----
+
 include::../requirements/core/REQ_links.adoc[]
 include::../recommendations/core/REC_distribution.adoc[]
 include::../recommendations/core/REC_links.adoc[]


### PR DESCRIPTION
As discussed at [TT-WISMD 2022-06-15](https://github.com/wmo-im/tt-wismd/wiki/Meeting-2022-06-15#notes), this PR adds an security object to our link definition/object, leveraging OpenAPI 3.1 security scheme definitions.  Relevant discussion in OGC API - Records is in https://github.com/opengeospatial/ogcapi-records/issues/170

cc @gaubert @josusky for comment/review, as well as others in @wmo-im/tt-wismd