### PR TITLE
Revert "Correct link to image"

### DIFF
--- a/standard/sections/clause_6_informative_text.adoc
+++ b/standard/sections/clause_6_informative_text.adoc
@@ -71,7 +71,7 @@ common meteorological data types:
 
 [[metadata-discovery-workflow]]
 .Discovery metadata workflow
-image::../images/metadata-discovery-workflow.png[Discovery metadata workflow]
+image::images/metadata-discovery-workflow.png[Discovery metadata workflow]
 
 Common meteorological data types include:
 


### PR DESCRIPTION
This reverts commit 0af6b64395acbffc4dca8d3e597f36b495b5689c.  Image links are relative to the master document.