### PR TITLE
update eumetsat-seviri.json example with the latest standard developm…

### DIFF
--- a/examples/eumetsat-seviri.json
+++ b/examples/eumetsat-seviri.json
@@ -88,29 +88,6 @@
                     "weatherObservations"
                 ],
                 "scheme": "https://wis.wmo.int/2012/codelists/WMOCodeLists.xml#WMO_CategoryCode#MD_KeywordTypeCode_theme"
-            },
-            {
-                "concepts": [
-                    "EDHA",
-                    "EDHI",
-                    "EDHK",
-                    "EDJA",
-                    "EDMO",
-                    "EDOP",
-                    "EDTD",
-                    "EDTL",
-                    "EDTY",
-                    "EDVE",
-                    "EDXW",
-                    "EDZO"
-                ],
-                "scheme": "https://wis.wmo.int/2012/codelists/WMOCodeLists.xml#WMO_CategoryCode#MD_KeywordTypeCode_place"
-            },
-            {
-                "concepts": [
-                    "GlobalExchange"
-                ],
-                "scheme": "https://wis.wmo.int/2012/codelists/WMOCodeLists.xml#WMO_CategoryCode#MD_KeywordTypeCode_dataCentre"
             }
         ],
         "formats": [

--- a/examples/eumetsat-seviri.json
+++ b/examples/eumetsat-seviri.json
@@ -1,6 +1,16 @@
 {
     "id": "urn:x-wmo:md:int.eumetsat::EO:EUM:DAT:MSG:HRSEVIRI",
     "type": "Feature",
+    "conformsTo": [
+        "http://wis.wmo.int/spec/wcmp/2.0"
+    ],
+    "time": {
+          "interval": [
+             [ "2009-03-23T00:00:00Z", null ]
+                        
+          ],
+          "resolution": "PT15M"
+    },
     "geometry": {
         "type": "Polygon",
         "coordinates": [
@@ -68,6 +78,12 @@
         "themes": [
             {
                 "concepts": [
+                    "wis2/XXA/EUMETSAT/data/recommended/weather/observation"
+                ],
+                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy"
+            },
+            {
+                "concepts": [
                     "meteorology",
                     "weatherObservations"
                 ],
@@ -132,22 +148,20 @@
                 }
             }
         ],
-        "association": [
+        "links": [
+            {
+                "rel"       : "subscribe",
+                "type"      : "application/json",
+                "title"     : "Message Broker EUMETSAT",
+                "href"      : "mqtts://wis2.eumetsat.int",
+                "wmo:topic" : "origin/v01/wis2/XXA/EUMETSAT/data/recommended/weather/observation"
+            },
             {
                 "protocol": "https",
                 "directDownloadURL": "true",
                 "title": "EUMETView, the EUMETSAT near real time visualization service",
                 "href": "https://eumetview.eumetsat.int/geoserv/wms?styles=raster&format=image%2Fgeotiff&height=3712&bbox=-77%2C-77%2C77%2C77&transparent=true&layers=meteosat%3Amsg_ir108&crs=EPSG%3A4326&service=WMS&request=GetMap&width=3712&version=1.3.0&exceptions=inimage"
             },
-            {
-                "protocol": "amqps",
-                "title": "WIS Message System GISC Offenbach",
-                "broker": "https://oflkd013.dwd.de",
-                "exchange": "wisof",
-                "topic/routing_key": "v03/wis/de/offenbach/surface/aviation/metar/de"
-            }
-        ],
-        "links": [
             {
                 "rel": "resources",
                 "type": "text/html",


### PR DESCRIPTION
Hi @tomkralidis @amilan17 @jsieland @Amienshxq @solson-nws @josusky,

I have updated the EUMETSAT example prior to create a new one for another EUMETSAT product, I will wait to finalise this one as I have the following comment/questions:

**_1.  temporal information/extent._**
I have created the temporal information at the root level using the example from @jsieland  (Thanks a lot for the work done btw) https://github.com/wmo-im/wcmp2/blob/main/examples/wcmp2_de.dwd.icon-eps.ALL.json and I have a suggestion. I see some examples provided bluntly without any explanation regarding how to encode the time information. It took me a lot of time to understand how @jsieland had described the temporal information and I only understood it from the description provided in the metadata. It is a particular way of describing the temporal information because it is a forecast with two time dimensions (the model run time and the forecast time). The same forecast time/model run time information could be defined differently. Could we have some information in the example provided in the standard and recommend for all forecast data to define the time information in a similar way ? Otherwise it will be very difficult to take advantage in a portal of the information.

**_2. Can I get rid of the following information ?_**
I don't know why it is there anymore. I think that I kept it for being compliant with the WIS but I can't remember why.

```
{
                "concepts": [
                    "EDHA",
                    "EDHI",
                    "EDHK",
                    "EDJA",
                    "EDMO",
                    "EDOP",
                    "EDTD",
                    "EDTL",
                    "EDTY",
                    "EDVE",
                    "EDXW",
                    "EDZO"
                ],
                "scheme": "https://wis.wmo.int/2012/codelists/WMOCodeLists.xml#WMO_CategoryCode#MD_KeywordTypeCode_place"
            },
```

and

 ```
 {
         "concepts": [
             "GlobalExchange"
         ],
         "scheme": "https://wis.wmo.int/2012/codelists/WMOCodeLists.xml#WMO_CategoryCode#MD_KeywordTypeCode_dataCentre"
}
```

Can I get rid of them ?

**_3.Format in mime types always ?_**

I've seen that @jsieland has defined the format without using the corresponding mime type. Should we recommend to always use a mime type ?

```
        "formats": [ 
            "GRIB2"                                                                         
        ] 
```

should it be defined using the mime type instead ? 

```
        "formats": [ 
            "application/wmo-grib"                                                                         
        ] 
```

This is also as we have defined our formats including proprietary formats: (x-eum-msg-native)

```
"formats": [
            "application/x-geotiff",
            "application/x-jpeg",
            "application/x-png",
            "application/zip",
            "application/x-eum-msg-native",
            "application/x-eum-hrit",
            "application/netcdf",
            "application/x-hdf"
        ],

```

Thanks once this solve it can be merged in the main branch