### PR TITLE
Add more time info and clarification for complex temporal extents

### DIFF
--- a/standard/abstract_tests/core/ATS_test_extent_temporal.adoc
+++ b/standard/abstract_tests/core/ATS_test_extent_temporal.adoc
@@ -20,7 +20,7 @@ Check that the `+time+` object is one of `+date+` string, `+timestamp+` string, 
 
 [.component,class=step]
 --
-Check that all non-null `+time+` values are valid RFC3339 representations, or `+..+` for an open-ended extent.
+Check that all non-null `+time+` values are valid ISO8601 representations, or `+..+` for an open-ended extent.
 --
 
 =====

--- a/standard/recommendations/core/REC_extent_temporal.adoc
+++ b/standard/recommendations/core/REC_extent_temporal.adoc
@@ -3,4 +3,5 @@
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/extent_temporal*
 ^|A |For datasets with known or discrete intervals, a WCMP record SHOULD provide the temporal resolution (`+time.resolution+`) as a valid ISO 8601 duration (e.g., `+P1D+`).
+^|B |For complex temporal extents a WCMP record SHOULD also provide a human-readable explanation in `+properties.description+` to promote clarification and unambiguity.
 |===

--- a/standard/recommendations/core/REC_extent_temporal.adoc
+++ b/standard/recommendations/core/REC_extent_temporal.adoc
@@ -2,8 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/extent_temporal*
-^|A |Within `time.interval` durations SHOULD be provided as a valid ISO 8601 duration (e.g., `+P1D+`).
-^|B |For datasets with known or discrete intervals, a WCMP record SHOULD provide the temporal resolution (`+time.resolution+`) as a valid ISO 8601 duration (e.g., `+P1D+`).
-^|C |For complex temporal extents a WCMP record SHOULD also provide a human-readable explanation in `+properties.description+` to promote clarification and unambiguity.
-|===
+^|A |For datasets with known or discrete intervals, a WCMP record SHOULD provide the temporal resolution (`+time.resolution+`) as a valid ISO 8601 duration (e.g., `+P1D+`).
+^|B |For complex temporal extents a WCMP record SHOULD also provide a human-readable explanation in `+properties.description+` to promote clarification and unambiguity.
+^|C |To distinguish maintenance or update frequency, those SHOULD be included in `+properties.themes+`.
 |===

--- a/standard/recommendations/core/REC_extent_temporal.adoc
+++ b/standard/recommendations/core/REC_extent_temporal.adoc
@@ -2,6 +2,8 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/extent_temporal*
-^|A |For datasets with known or discrete intervals, a WCMP record SHOULD provide the temporal resolution (`+time.resolution+`) as a valid ISO 8601 duration (e.g., `+P1D+`).
-^|B |For complex temporal extents a WCMP record SHOULD also provide a human-readable explanation in `+properties.description+` to promote clarification and unambiguity.
+^|A |Within `time.interval` durations SHOULD be provided as a valid ISO 8601 duration (e.g., `+P1D+`).
+^|B |For datasets with known or discrete intervals, a WCMP record SHOULD provide the temporal resolution (`+time.resolution+`) as a valid ISO 8601 duration (e.g., `+P1D+`).
+^|C |For complex temporal extents a WCMP record SHOULD also provide a human-readable explanation in `+properties.description+` to promote clarification and unambiguity.
+|===
 |===

--- a/standard/requirements/core/REQ_extent_temporal.adoc
+++ b/standard/requirements/core/REQ_extent_temporal.adoc
@@ -4,4 +4,5 @@
 ^|*Requirement {counter:req-id}* |*/req/core/extent_temporal*
 ^|A |A WCMP record SHALL provide ONE `+time+` item property using the Gregorian calendar.
 ^|B |A WCMP record SHALL provide the value of `+null+` when a conformant time cannot be derived.
+^|C |All non-null `+time+` values SHALL be valid ISO8601 representations or `+..+` for an open-ended extent.
 |===

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -384,21 +384,27 @@ include::../recommendations/core/REC_extent_temporal.adoc[]
 }
 ----
 
+In some cases more than one time dimension are at hand, e.g. when describing forecast models. In those cases it is necessary to describe intervals covering the model run time (=start) up to the range covered (=end). Additionally the time steps of the model forecast need to be indicated (=resolution). To ensure clarity an additional human-readable explanation should be given in the `+properties.description+`.
+
+.Example: complex time intervals with corresponding resolution and additional explanation
+
 [source, json]
 ----
 "time": {
   "interval": [
-    ["R/T00Z", "PT180H"],
-    ["R/T12Z", "PT180H"]
+    ["T00Z", "PT180H"],
+    ["T12Z", "PT180H"]
   ],
   "resolution": "PT6H"
+},
+"properties": {
+  ...
+  "description": "[...] up to +180h every 6h, runs 00/12 UTC [...]."
+  ...
 }
 ----
 
-[source,json]
-----
-"time": null
-----
+If necessary further granularity can be indicated by the `+additionalExtents.temporal+` property.
 
 ===== Additional Temporal Extents
 The `+additionalExtents.temporal+` property is for describing other temporal extents associated with the dataset, for example, multiple time instances or to identify other temporal reference systems. 

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -384,23 +384,61 @@ include::../recommendations/core/REC_extent_temporal.adoc[]
 }
 ----
 
-In some cases more than one time dimension are at hand, e.g. when describing forecast models. In those cases it is necessary to describe intervals covering the model run time (=start) up to the range covered (=end). Additionally the time steps of the model forecast need to be indicated (=resolution). To ensure clarity an additional human-readable explanation should be given in the `+properties.description+`.
+[source,json]
+----
+"time": {
+  "interval" : ["2020-10-30T06:00:00Z", ".."],
+  "resolution": "P1D"
+}
+----
 
-.Example: complex time intervals with corresponding resolution and additional explanation
+[source,json]
+----
+"time": null
+----
+
+If only times are given for the interval, it is implicitly assumed that those are recurring every day.
+
+[source,json]
+----
+"time": {
+  "interval" : ["T00Z", "T23Z"],
+  "resolution": "PT1H"
+}
+----
+
+Some cases might be more complex due to the product's characteristics. 
+
+The example below describes two intervals with the model run time (=start) up to the range covered by the model run (=end). Here the end of the interval is characterised by a time period. Additionally the time steps within the model range are relevant information (=resolution).
+
+To ensure clarity an additional human-readable explanation is given in the `+properties.description+`.
+Further time-related characteristics (e.g. frequency of modifications, available data or else) should be added in `+properties.themes+`.
+
+.Example: complex time information with additional explanation and characteristics
 
 [source, json]
 ----
 "time": {
-  "interval": [
-    ["T00Z", "PT180H"],
-    ["T12Z", "PT180H"]
-  ],
-  "resolution": "PT6H"
+    "interval": [
+        ["T00Z", "PT180H"],
+        ["T12Z", "PT180H"]
+    ],
+    "resolution": "PT6H"
 },
 "properties": {
-  ...
-  "description": "[...] up to +180h every 6h, runs 00/12 UTC [...]."
-  ...
+    ...
+    "description": "[...] up to +180h every 6h, runs 00/12 UTC [...]."
+    ...
+    "themes": [
+        {
+        "concepts": [
+            {"id": "continual"}
+        ],
+        "scheme": "https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_FrequencyCode"
+        }
+        ...
+    ]
+    ...
 }
 ----
 


### PR DESCRIPTION
Hi @tomkralidis @gaubert @amilan17 @josusky @Amienshxq @solson-nws,

as discussed in https://github.com/wmo-im/wcmp2/pull/81 I made a draft for adding more time info for complex temporal extents (based on this example: https://github.com/wmo-im/wcmp2/blob/main/examples/wcmp2_de.dwd.icon-eps.ALL.json).

<details><summary>previous draft</summary>

I tried to no overcomplicate things - for the understanding of users and for simplicity regarding any validation. Perhaps it's worth to consider having other more complex examples and description in the WIS guide.

#### 1. In the complex example remove the "R/" 
Because it is a more or less straight (and discussable) ISO 8601 representation for intervals. According to WCMP2 `interval` should have date-time based on RFC3339 - although it is a profile of ISO 8601 this might be confusing. _EDIT: Initially I forgot to include the recommendation for using durations in `time.interval`. The idea is that date-time is still based on RFC3339 but durations are given in ISO8601 (because those are not covered by the RFC)._

At the moment with just a time-string (indicated by the leading "T") it is implicit that this time is repeated daily. Depending on what people think I could add more elaboration.

#### 2. added an additional recommendation for human-readable explanation
Nevertheless some temporal extents might be complex, so there should be and additional human-readable explanation in `properties.description` for clarification. 

#### 3. put complex example last
More editorial: I changed the order of the examples, put the complex example last with some explanation regarding the example and made some transition to next chapter. 

</details>

After feedback from TT-NWPMD meeting and further discussions I updated my previous draft. My aim was to find something that is flexible/precise but is still fairly easy to understand. My main points are the following:

#### 1) Proposal: use ISO8601 instead of RFC3339
The main reason is to allow durations (which are not covered by RFC3339). Moreover ISO8601 provides more (in my opinion) more flexibilty regarding times

#### 2) recommend additional time-related characteristics in themes
The `time` should only relate to the described data and not the update/maintenance/etc. frequency. This should be stated in `properties.themes`. Nevertheless the `properties.description` should provide overall context.


I updated the PR accordingly and also made some further adjustements:
- update ATS: change according to proposal
- update REQ: change according to proposal, add statement about open intervals
- add example for open interval
- add example and text for only using time in interval
- update REC: add part for frequency
- add complex example including explanation



As always, feedback is greatly appreciated.