### PR TITLE
editorial updates, update spec URI

### DIFF
--- a/examples/msc-climate-daily.json
+++ b/examples/msc-climate-daily.json
@@ -143,7 +143,7 @@
         },
         {
             "rel": "items",
-            "href": "mqtt://example.org:8883",
+            "href": "mqtts://example.org",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/climate/observations",
             "type": "application/json",
             "title": "Data notifications"

--- a/examples/msc-climate-daily.json
+++ b/examples/msc-climate-daily.json
@@ -1,7 +1,7 @@
 {
     "id": "urn:x-wmo:md:can:eccc-msc:climate.climate-daily",
     "conformsTo": [
-        "http://wis.wmo.int/spec/wcmp/2.0/conf/core"
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
     ],
     "type": "Feature",
     "geometry": {
@@ -143,7 +143,7 @@
         },
         {
             "rel": "items",
-            "href": "mqtts://example.org",
+            "href": "mqtt://example.org:8883",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/climate/observations",
             "type": "application/json",
             "title": "Data notifications"

--- a/examples/msc-cmip5-tt.json
+++ b/examples/msc-cmip5-tt.json
@@ -1,7 +1,7 @@
 {
     "id": "urn:x-wmo:md:can:eccc-msc:climate.cmip5.tt.rcp85.year.2081-2100_pctl5",
     "conformsTo": [
-        "http://wis.wmo.int/spec/wcmp/2.0/conf/core"
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
     ],
     "type": "Feature",
     "geometry": {

--- a/examples/msc-gdps-eta-tt.json
+++ b/examples/msc-gdps-eta-tt.json
@@ -140,7 +140,7 @@
         {
             "rel": "items",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/weather/nwp/global",
-            "href": "mqtt://example.org:8883",
+            "href": "mqtts://example.org",
             "type": "application/json",
             "title": "Data notifications"
         }

--- a/examples/msc-gdps-eta-tt.json
+++ b/examples/msc-gdps-eta-tt.json
@@ -1,7 +1,7 @@
 {
     "id": "urn:x-wmo:md:can:eccc-msc:nwp.msc_nwp_gdps",
     "conformsTo": [
-        "http://wis.wmo.int/spec/wcmp/2.0/conf/core"
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
     ],
     "type": "Feature",
     "geometry": {
@@ -140,7 +140,7 @@
         {
             "rel": "items",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/weather/nwp/global",
-            "href": "mqtts://example.org",
+            "href": "mqtt://example.org:8883",
             "type": "application/json",
             "title": "Data notifications"
         }

--- a/examples/msc-hydat.json
+++ b/examples/msc-hydat.json
@@ -1,7 +1,7 @@
 {
     "id": "urn:x-wmo:md:can:eccc-msc:hydrometric.hydat",
     "conformsTo": [
-        "http://wis.wmo.int/spec/wcmp/2.0/conf/core"
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
     ],
     "type": "Feature",
     "geometry": {
@@ -148,7 +148,7 @@
         },
         {
             "rel": "items",
-            "href": "mqtts://example.org",
+            "href": "mqtt://example.org:8883",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/hydrology",
             "type": "application/json",
             "title": "Data notifications"

--- a/examples/msc-hydat.json
+++ b/examples/msc-hydat.json
@@ -148,7 +148,7 @@
         },
         {
             "rel": "items",
-            "href": "mqtt://example.org:8883",
+            "href": "mqtts://example.org",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/hydrology",
             "type": "application/json",
             "title": "Data notifications"

--- a/examples/msc-hydrometric-realtime.json
+++ b/examples/msc-hydrometric-realtime.json
@@ -143,7 +143,7 @@
         },
         {
             "rel": "items",
-            "href": "mqtt://example.org:8883",
+            "href": "mqtts://example.org",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/hydrology",
             "type": "application/json",
             "title": "Data notifications"

--- a/examples/msc-hydrometric-realtime.json
+++ b/examples/msc-hydrometric-realtime.json
@@ -1,7 +1,7 @@
 {
     "id": "urn:x-wmo:md:can:eccc-msc:hydrometric.realtime",
     "conformsTo": [
-        "http://wis.wmo.int/spec/wcmp/2.0/conf/core"
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
     ],
     "type": "Feature",
     "geometry": {
@@ -143,7 +143,7 @@
         },
         {
             "rel": "items",
-            "href": "mqtts://example.org",
+            "href": "mqtt://example.org:8883",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/hydrology",
             "type": "application/json",
             "title": "Data notifications"

--- a/examples/msc-swob-realtime.json
+++ b/examples/msc-swob-realtime.json
@@ -1,7 +1,7 @@
 {
     "id": "urn:x-wmo:md:can:eccc-msc:weather.observations.swob-realtime",
     "conformsTo": [
-        "http://wis.wmo.int/spec/wcmp/2.0/conf/core"
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
     ],
     "time": {
         "interval": [
@@ -150,7 +150,7 @@
         },
         {
             "rel": "items",
-            "href": "mqtts://example.org",
+            "href": "mqtt://example.org:8883",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/weather/observations/surface-land/landFixed",
             "type": "application/json",
             "title": "Data notifications"

--- a/examples/msc-swob-realtime.json
+++ b/examples/msc-swob-realtime.json
@@ -150,7 +150,7 @@
         },
         {
             "rel": "items",
-            "href": "mqtt://example.org:8883",
+            "href": "mqtts://example.org",
             "channel": "origin/a/wis2/can/eccc-msc/data/core/weather/observations/surface-land/landFixed",
             "type": "application/json",
             "title": "Data notifications"

--- a/examples/wcmp2_de.dwd.icon-eps.ALL.json
+++ b/examples/wcmp2_de.dwd.icon-eps.ALL.json
@@ -136,7 +136,7 @@
                 "rel": "items",
                 "type": "application/json",
                 "title": "Message Broker DWD",
-                "href": "mqtt://everyone:everyone@wis2.dwd.de:8883",
+                "href": "mqtts://everyone:everyone@wis2.dwd.de",
                 "channel": "origin/a/wis2/deu/dwd-offenbach/data/core/weather/analysis-prediction/forecast/model/#"
             }
         ],

--- a/examples/wcmp2_de.dwd.icon-eps.ALL.json
+++ b/examples/wcmp2_de.dwd.icon-eps.ALL.json
@@ -136,7 +136,7 @@
                 "rel": "items",
                 "type": "application/json",
                 "title": "Message Broker DWD",
-                "href": "mqtts://everyone:everyone@wis2.dwd.de/",
+                "href": "mqtt://everyone:everyone@wis2.dwd.de:8883",
                 "channel": "origin/a/wis2/deu/dwd-offenbach/data/core/weather/analysis-prediction/forecast/model/#"
             }
         ],

--- a/standard/abstract_tests/ATS_class_core.adoc
+++ b/standard/abstract_tests/ATS_class_core.adoc
@@ -1,7 +1,7 @@
 [[ats_core]]
 ====
 [%metadata]
-label:: http://www.wmo.int/spec/wcmp/2.0/conf/core
+label:: http://www.wmo.int/spec/wcmp/2/conf/core
 subject:: Requirements Class "core"
 classification:: Target Type:Discovery Metadata
 ====

--- a/standard/abstract_tests/core/ATS_test_conformance.adoc
+++ b/standard/abstract_tests/core/ATS_test_conformance.adoc
@@ -14,7 +14,7 @@ Check for the existence of a `+conformsTo+` property in the WCMP record.
 
 [.component,class=step]
 --
-In the WCMP record's `+conformsTo+` array property, check that ONE of the values is equal to `+http://wmo.int/spec/wcmp/2.0/conf/core+`.
+In the WCMP record's `+conformsTo+` array property, check that ONE of the values is equal to `+http://wmo.int/spec/wcmp/2/conf/core+`.
 --
 =====
 ====

--- a/standard/abstract_tests/core/ATS_test_links.adoc
+++ b/standard/abstract_tests/core/ATS_test_links.adoc
@@ -19,7 +19,7 @@ Check that the `+links+` property provides a minimum of one link object.
 
 [.component,class=step]
 --
-For a link object describing real-time data, check that the `+href+` property starts with the `+mqtt+` protocol, AND that `+channel+` is additionally defined.
+For a link object describing real-time data, check that the `+href+` property starts with the `+mqtt+` or `+mqtts+` protocol, AND that `+channel+` is additionally defined.
 --
 
 [.component,class=step]

--- a/standard/abstract_tests/core/ATS_test_links.adoc
+++ b/standard/abstract_tests/core/ATS_test_links.adoc
@@ -19,7 +19,7 @@ Check that the `+links+` property provides a minimum of one link object.
 
 [.component,class=step]
 --
-For a link object describing real-time data, check that the `+href+` property starts with the `+mqtt+` or `+mqtts+` protocol, AND that `+channel+` is additionally defined.
+For a link object describing real-time data, check that the `+href+` property starts with the `+mqtt+` protocol, AND that `+channel+` is additionally defined.
 --
 
 [.component,class=step]

--- a/standard/abstract_tests/core/ATS_test_themes.adoc
+++ b/standard/abstract_tests/core/ATS_test_themes.adoc
@@ -24,7 +24,7 @@ Check that each theme object provides a minimum of one `+concepts+` property.
 
 [.component,class=step]
 --
-Check that each theme object provides a minimum of one `+scheme+` property.
+Check that each theme object provides one `+scheme+` property.
 --
 
 [.component,class=step]

--- a/standard/asciidoc-link-check-config.json
+++ b/standard/asciidoc-link-check-config.json
@@ -2,6 +2,6 @@
     "ignorePatterns": [
         { "pattern": "^http://www.opengis.net/def"},
         { "pattern": "^https://example.org"},
-        { "pattern": "http://www.wmo.int/spec/wcmp/2.0/conf/core" }
+        { "pattern": "http://www.wmo.int/spec/wcmp/2"}
     ]
 }

--- a/standard/requirements/core/REQ_themes.adoc
+++ b/standard/requirements/core/REQ_themes.adoc
@@ -3,4 +3,7 @@
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/themes*
 ^|A |A WCMP record SHALL use themes/concepts when describing a dataset based on an associated controlled vocabulary.
+^|B |A WCMP record SHALL provide at least one theme.
+^|C |Within each theme, a WCMP record SHALL provide at least one concept.
+^|D |Within each theme, a WCMP record SHALL provide a schema that refers to a controlled vocabulary or thesaurus.
 |===

--- a/standard/requirements/requirements_class_core.adoc
+++ b/standard/requirements/requirements_class_core.adoc
@@ -2,7 +2,7 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class*
-2+|http://www.wmo.int/spec/wcmp/2.0/conf/core
+2+|http://www.wmo.int/spec/wcmp/2/conf/core
 |Target type |Discovery Metadata
 |Dependency |<<rfc8259,IETF RFC 8259: The JavaScript Object Notation (JSON) Data Interchange Format>>
 |Dependency |<<json-schema, JSON Schema>>

--- a/standard/sections/annex_b_schemas.adoc
+++ b/standard/sections/annex_b_schemas.adoc
@@ -3,12 +3,11 @@
 :appendix-caption: Annex
 == Schemas (Normative)
 
-NOTE: The schema document will only be published on `schemas.wmo.int` once the standard has been approved.
+NOTE: The schema document will be published on http://schemas.wmo.int/wcmp/2.0 once the standard has been approved.
 
 === WMO Core Metadata Profile Schema
 
-[source,yaml]
+[source,json]
 ----
-include::../../schemas/wcmpRecordGeoJSON.yaml[]
+include::../../schemas/wcmp2-bundled.json[]
 ----
-

--- a/standard/sections/annex_d_codelists.adoc
+++ b/standard/sections/annex_d_codelists.adoc
@@ -1,4 +1,4 @@
 [appendix]
 :appendix-caption: Annex
 [[Codelists]]
-= Codelists
+= Codelists (Normative)

--- a/standard/sections/clause_1_scope.adoc
+++ b/standard/sections/clause_1_scope.adoc
@@ -14,4 +14,4 @@ may be represented as part of their own metadata or associated through WCMP link
 
 WCMP discovery metadata record provides descriptions at the granularity level of a dataset.  Station, instrument and observation metadata are supported by the _WIGOS Metadata Standard (WMO-No. 1192)_ footnote:[https://library.wmo.int/doc_num.php?explnum_id=10109].
 
-This specification defines the conformance requirements for the WMO Core Metadata Profile.  Annex A defines the abstract test suite. Annex B provides normative information on codelists.
+This specification defines the conformance requirements for the WMO Core Metadata Profile.  Annex A defines the abstract test suite. Annex B provides normative information on schemas.  Annex provides informative examples.  Annex D provides normative information on codelists.

--- a/standard/sections/clause_5_conventions.adoc
+++ b/standard/sections/clause_5_conventions.adoc
@@ -4,7 +4,7 @@ This section provides details and examples for any conventions used in the docum
 === Identifiers
 The normative provisions in this Standard are denoted by the URI:
 
-http://wis.wmo.int/spec/wcmp/2.0
+http://wis.wmo.int/spec/wcmp/2
 
 All requirements and conformance tests that appear in this document are denoted by partial URIs which are relative to this base.
 
@@ -16,7 +16,7 @@ Complete examples can be found at https://schemas.wmo.int/wcmp/2.0/examples
 
 === Schemas
 
-The WCMP schema can be found at https://schemas.wmo.int/wcmp/2.0/wcmpRecordGeoJSON.yaml 
+The WCMP schema can be found at https://schemas.wmo.int/wcmp/2.0/wcmp2-bundled.json
 
 === Schema representation
 
@@ -24,7 +24,7 @@ JSON Schema footnote:[https://json-schema.org] objects are used throughout this 
 of metadata records. These schema objects are also typically represented using YAML footnote:[https://en.wikipedia.org/wiki/YAML].
 YAML is a superset of JSON, and in this standard are regarded as equivalent.
 
-Metadata record instances are always defined as JSON.
+Metadata record instances are always represented as JSON.
 
 ==== Properties
 

--- a/standard/sections/clause_6_informative_text.adoc
+++ b/standard/sections/clause_6_informative_text.adoc
@@ -2,8 +2,7 @@
 
 === Overview
 
-The initial WIS technical specifications were developed using service-oriented architecture (SOA) principles.  It featured complex ISO 19115/19139-based XML for metadata. Since then, authoritative
-groups such as W3C and OGC have moved to adopt a more resource-oriented architecture (ROA), leveraging RESTful design patterns, and mass market encodings such as JSON and HTML.
+The initial WIS technical specifications were developed using service-oriented architecture (SOA) principles.  It featured complex ISO 19115/19139-based XML for metadata. Since then, international standards development organizations such as W3C and OGC have moved to adopt a more resource-oriented architecture (ROA), leveraging RESTful design patterns, and mass market encodings such as JSON and HTML.
 
 Aligning with the WIS2 Principles, in order to support the WIS2 Technical Specifications for discovery and search, discovery metadata will be published to a global discovery catalogue, which will provide an OGC API - Records searchable functionality.  Users will be able to search from a web browser, whereas machines will interact with an API.
 
@@ -38,7 +37,7 @@ In order to provide discovery metadata of value, it is important to clarify the 
 are to provide describing their data and associated services.  Articulating the level of granularity will reduce catalogue "pollution"
 and bring the user closer to the data via their search criteria.
 
-A WCMP record provides a description at the granularity of a dataset, which facilitates clear
+A WCMP record provides a description at the granularity of a *dataset*, which facilitates clear
 cataloguing and discovery workflow, in combination with data services or APIs, which provide
 access, queries, and filters at a lower level of granularity (parameter, variable, spatiotemporal extents).
 
@@ -113,8 +112,8 @@ The OGC Records - API - Part 1: Core specification:
 The GDC will provide a central search endpoint, enabling users to traverse, browse and search
 data holdings in WIS2.  Key search predicate capabilities include:
 
-* geospatial
-* temporal (time instant or time period)
+* geospatial (`+bbox=+`)
+* temporal (time instant or time period) (`+datetime=+`)
 * equality predicates (i.e. `+property=value+`) for any defined discovery metadata property
 * full-text (`+q=+`)
 

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -135,7 +135,7 @@ include::../requirements/core/REQ_conformance.adoc[]
 [source,json]
 ----
 "conformsTo": [
-  "http://wis.wmo.int/spec/wcmp/2.0/conf/core"
+  "http://wis.wmo.int/spec/wcmp/2/conf/core"
 ]
 ----
 
@@ -693,7 +693,7 @@ include::../requirements/core/REQ_links.adoc[]
     "rel"  : "items",
     "type" : "application/json",
     "title": "WIS2 notification service",
-    "href" : "mqtts://broker.example.org",
+    "href" : "mqtt://broker.example.org:8883",
     "channel": "cache/a/wis2/can/eccc-msc/data/core/weather/surface-based-observations"
   }
 ]

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -371,7 +371,10 @@ include::../recommendations/core/PER_extent_geospatial.adoc[]
 
 ===== Temporal Extent
 The `+time+` property describes the general bounding extent of the dataset and the temporal resolution. 
+
 Temporal extents provide a useful indicator of the date and time period of the dataset and facilitates temporal searching in the GDC. 
+
+Temporal resolution provides a useful indicator of the data update frequency (for example, for real-time datasets).
 
 include::../requirements/core/REQ_extent_temporal.adoc[]
 include::../recommendations/core/REC_extent_temporal.adoc[]

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -696,7 +696,7 @@ include::../requirements/core/REQ_links.adoc[]
     "rel"  : "items",
     "type" : "application/json",
     "title": "WIS2 notification service",
-    "href" : "mqtt://broker.example.org:8883",
+    "href" : "mqtts://broker.example.org",
     "channel": "cache/a/wis2/can/eccc-msc/data/core/weather/surface-based-observations"
   }
 ]


### PR DESCRIPTION
- ~change `mqtts://` links to `mqtt://`~
- various editorial updates
- update of the specification base URI from `http://wis.wmo.int/spec/wcmp/2.0/conf/core` to `http://wis.wmo.int/spec/wcmp/2/conf/core`, the main reason is being able to issue WCMP releases in the 2.x series over time without users having to update conformance in their WCMP2 documents.