### PR TITLE
safeguard time null support in WCMP2 schema

### DIFF
--- a/schemas/wcmp2-bundled.json
+++ b/schemas/wcmp2-bundled.json
@@ -31,48 +31,57 @@
       ]
     },
     "time": {
-      "type": "object",
-      "nullable": true,
-      "properties": {
-        "date": {
-          "type": "string",
-          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+      "oneOf": [
+        {
+          "enum": [
+            null
+          ]
         },
-        "timestamp": {
-          "type": "string",
-          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
-        },
-        "interval": {
-          "type": "array",
-          "minItems": 2,
-          "maxItems": 2,
-          "items": {
-            "oneOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
-              },
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
-              },
-              {
-                "type": "string",
-                "enum": [
-                  ".."
+        {
+          "type": "object",
+          "nullable": true,
+          "properties": {
+            "date": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            },
+            "timestamp": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+            },
+            "interval": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      ".."
+                    ]
+                  }
                 ]
               }
-            ]
+            },
+            "resolution": {
+              "type": "string",
+              "description": "Minimum time period resolvable in the dataset, as an ISO 8601 duration",
+              "example": [
+                "P1D"
+              ]
+            }
           }
-        },
-        "resolution": {
-          "type": "string",
-          "description": "Minimum time period resolvable in the dataset, as an ISO 8601 duration",
-          "example": [
-            "P1D"
-          ]
         }
-      }
+      ]
     },
     "geometry": {
       "oneOf": [

--- a/schemas/wcmpRecordGeoJSON.yaml
+++ b/schemas/wcmpRecordGeoJSON.yaml
@@ -19,7 +19,10 @@ properties:
   type:
     $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/schemas/recordGeoJSON.yaml#/properties/type'
   time:
-    $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/schemas/recordGeoJSON.yaml#/properties/time'
+    oneOf:
+      - enum:
+        - null
+      - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/schemas/recordGeoJSON.yaml#/properties/time'
   geometry:
     $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/schemas/recordGeoJSON.yaml#/properties/geometry'
   additionalExtents:


### PR DESCRIPTION
Given the `null` compatibility [issue](https://gist.github.com/tomkralidis/cc674035706640d93a1f9527f18cb91a) between OpenAPI and JSON Schema, this PR safeguards defining time as null.