### PR TITLE
Update clause_7_normative_text.adoc

### DIFF
--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -496,7 +496,7 @@ include::../recommendations/core/PER_extent_temporal.adoc[]
         null
       ]
     ],
-    "resolution": "P1H",
+    "resolution": "PT1H",
     "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"
   }
 }


### PR DESCRIPTION
Example in section "7.1.11.3. Additional Temporal Extents" specifies temporal interval as `P1H` that does not seem to adhere to the ISO-8601 standard. 