### PR TITLE
rec/core/identifier: allows colons in local identifier

### DIFF
--- a/standard/abstract_tests/core/ATS_test_identifier.adoc
+++ b/standard/abstract_tests/core/ATS_test_identifier.adoc
@@ -14,7 +14,7 @@ Check for the existence of an `+id+` property in the WCMP record.
 
 [.component,class=step]
 --
-In the WCMP record's `+id+` property, check that there are **five** tokens, delimited by `+:+`.
+In the WCMP record's `+id+` property, check that there are at least **six** tokens, delimited by `+:+`.
 --
 
 [.component,class=step]

--- a/standard/recommendations/core/PER_identifier.adoc
+++ b/standard/recommendations/core/PER_identifier.adoc
@@ -1,0 +1,6 @@
+[[per_core_identifier]]
+[width="90%",cols="2,6a"]
+|===
+^|*Permission {counter:per-id}* |*/rec/core/identifier*
+^|A |A WCMP record identifier's local identifier MAY also have colons (`+:+`) as required by the data publisher.
+|===

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -119,6 +119,7 @@ of the dataset.  A record identifier is essential for querying and identifying
 records within the GDC.
 
 include::../requirements/core/REQ_identifier.adoc[]
+include::../recommendations/core/PER_identifier.adoc[]
 
 .Example
 


### PR DESCRIPTION
A WCMP2 identifier should have AT LEAST six tokens (local identifiers themselves may have tokens as needed).