### PR TITLE
Dwd examples

### DIFF
--- a/examples/de-dwd.global-cache.json
+++ b/examples/de-dwd.global-cache.json
@@ -39,8 +39,8 @@
     },
     "properties": {
         "type": "service",
-        "title": "WMO WIS2 Global Cache (Deutscher Wetterdienst)",
-        "description": "For WMO Information System 2 (WIS2) DWD provides a Global Cache Service. It offers the possibility to download cached core data from a single source. An automatic download is made possible by messages that are distributed worldwide and contain the actual download link. Subscription to receive the messages is possible via Global Brokers. General notes: 1) Maximum message size is limited to 4096 bytes, 2) Connected Global Brokers are Global Broker MF and Global Broker CMA, 3) During the test phase the data is not yet cached for 24 hours",
+        "title": "WIS2 Global Cache provided by German weather service",
+        "description": "For WMO Information System 2 (WIS2) Deutscher Wetterdienst, the German weather service, provides a Global Cache. It offers the possibility to download cached core data from a single source. An automatic download is made possible by messages that are distributed worldwide and contain the actual download link. Subscription to receive the messages is possible via Global Brokers. General notes: 1) Maximum message size is limited to 8192 bytes, 2) Connected Global Brokers are Global Broker MF, Global Broker CMA, and Global Broker NOAA, 3) During the test phase the data is not yet cached for 24 hours",
         "themes": [
             {
                 "concepts": [
@@ -82,7 +82,23 @@
                         "title": "Global Cache"
                     }
                 ],
-                "scheme": "https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/service-types.csv"
+                "scheme": "https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/global-service-type.csv"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "cache"
+                    }
+                ],
+                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/channel.csv"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "de-dwd"
+                    }
+                ],
+                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/centre-id.csv"
             },
             {
                 "concepts": [
@@ -129,7 +145,7 @@
             }
         ],
         "created": "2023-05-05T08:00:00Z",
-        "updated": "2023-05-19T08:00:00Z",
+        "updated": "2023-12-01T08:00:00Z",
         "keywords": [
             "WIS2",
             "Global Cache"
@@ -154,28 +170,6 @@
             "type": "text/html",
             "title": "Open Data Server DWD (Metadata Archive)",
             "href": "https://opendata.dwd.de/test/wis2/cache_metadata"
-        },
-        {
-            "rel": "related",
-            "type": "application/json",
-            "title": "WMO WIS2 Global Broker - M\u00e9t\u00e9o-France",
-            "href": "mqtts://everyone:everyone@globalbroker.meteo.fr:8883",
-            "channel": "cache/a/wis2/#",
-            "distribution": {
-                "maxMSGsize": 4096,
-                "unit": "bytes"
-            }
-        },
-        {
-            "rel": "related",
-            "type": "application/json",
-            "title": "WMO WIS Global Broker - China Meteorological Administration",
-            "href": "mqtt://everyone:everyone@gb.wis.cma.cn:1883",
-            "channel": "cache/a/wis2/#",
-            "distribution": {
-                "maxMSGsize": 4096,
-                "unit": "bytes"
-            }
         }
     ]
 }

--- a/examples/de-dwd.global-cache.json
+++ b/examples/de-dwd.global-cache.json
@@ -95,14 +95,6 @@
             {
                 "concepts": [
                     {
-                        "id": "de-dwd"
-                    }
-                ],
-                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/centre-id.csv"
-            },
-            {
-                "concepts": [
-                    {
                         "id": "continual"
                     }
                 ],
@@ -170,6 +162,13 @@
             "type": "text/html",
             "title": "Open Data Server DWD (Metadata Archive)",
             "href": "https://opendata.dwd.de/test/wis2/cache_metadata"
+        },
+        {
+            "rel": "items",
+            "channel": "cache/a/wis2",
+            "href": "mqtts://everyone:everyone@wis2.dwd.de:8883",
+            "type": "application/json",
+            "title": "Data notifications"
         }
     ]
 }

--- a/examples/de-dwd.icon-eps-all.json
+++ b/examples/de-dwd.icon-eps-all.json
@@ -157,7 +157,7 @@
             }
         ],
         "created": "2018-08-19T08:10:00Z",
-        "updated": "2022-03-15T09:26:00Z",
+        "updated": "2023-12-01T00:00:00Z",
         "wmo:dataPolicy": "core",
         "keywords": [
             "CLCH",

--- a/examples/de-dwd.icon-eps-all.json
+++ b/examples/de-dwd.icon-eps-all.json
@@ -109,14 +109,6 @@
                     }
                 ],
                 "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv"
-            },
-            {
-                "concepts": [
-                    {
-                        "id": "de-dwd"
-                    }
-                ],
-                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/centre-id.csv"
             }
         ],
         "contacts": [
@@ -198,6 +190,13 @@
             "type": "text/html",
             "title": "Open Data Server DWD",
             "href": "https://opendata.dwd.de/weather/wmc/icon-eps/data/grib"
+        },
+        {
+            "rel": "items",
+            "channel": "origin/a/wis2/de-dwd/data/core/weather/prediction/forecast/medium-range",
+            "href": "mqtts://everyone:everyone@wis2.dwd.de:8883",
+            "type": "application/json",
+            "title": "Data notifications"
         }
     ]
 }

--- a/examples/de-dwd.icon-eps-all.json
+++ b/examples/de-dwd.icon-eps-all.json
@@ -6,10 +6,9 @@
     ],
     "time": {
         "interval": [
-            "T00Z",
-            "T12Z"
-        ],
-        "resolution": "PT6H"
+            "2018-04-22",
+            ".."
+        ]
     },
     "geometry": {
         "type": "Polygon",
@@ -51,24 +50,24 @@
             "resolution": "0.5*0.5",
             "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
         },
-        "temporal": {
+        "temporal": { 
             "interval": [
                 [
                     "R/T00Z",
-                    "PT48H"
+                    "PT180H"
                 ],
                 [
                     "R/T12Z",
-                    "PT48H"
+                    "PT180H"
                 ]
             ],
-            "resolution": "PT1H",
+            "resolution": "PT6H",
             "trs": "http://www.opengis.net/def/trs/ISO-8601"
         }
     },
     "properties": {
         "type": "dataset",
-        "title": "ICON-EPS GRIB data",
+        "title": "Global Ensemble Prediction Model",
         "description": "ICON-EPS 0.5\u00b0 x 0.5\u00b0 regular lat/lon grid, up to +180h every 6h, runs 00/12 UTC, various parameter, various level, various threshold",
         "themes": [
             {
@@ -102,6 +101,22 @@
                     }
                 ],
                 "scheme": "https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_FrequencyCode"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "weather"
+                    }
+                ],
+                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "de-dwd"
+                    }
+                ],
+                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/centre-id.csv"
             }
         ],
         "contacts": [
@@ -136,7 +151,8 @@
                 ],
                 "contactInstructions": "email",
                 "roles": [
-                    "host"
+                    "host",
+                    "producer"
                 ]
             }
         ],
@@ -182,13 +198,6 @@
             "type": "text/html",
             "title": "Open Data Server DWD",
             "href": "https://opendata.dwd.de/weather/wmc/icon-eps/data/grib"
-        },
-        {
-            "rel": "items",
-            "type": "application/json",
-            "title": "Global Broker (Toulouse)",
-            "href": "mqtts://everyone:everyone@globalbroker.meteo.fr:8883",
-            "channel": "cache/a/wis2/deu/dwd-offenbach/data/core/weather/analysis-prediction/forecast/model/#"
         }
     ]
 }

--- a/examples/de-dwd.surface-weather-observations-realtime.json
+++ b/examples/de-dwd.surface-weather-observations-realtime.json
@@ -111,7 +111,7 @@
         ],
         "type": "dataset",
         "created": "2023-11-01",
-        "updated": "2023-11-01",
+        "updated": "2023-12-01",
         "wmo:dataPolicy": "core"
     },
     "links": [

--- a/examples/de-dwd.surface-weather-observations-realtime.json
+++ b/examples/de-dwd.surface-weather-observations-realtime.json
@@ -1,0 +1,131 @@
+{
+    "id": "urn:x-wmo:md:de-dwd:weather.observations.swob-realtime",
+    "conformsTo": [
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
+    ],
+    "time": {
+        "interval": [
+            "2024-01-01T00:00:00Z",
+            ".."
+        ]
+    },
+    "type": "Feature",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    5.87,
+                    47.27
+                ],
+                [
+                    5.87,
+                    55.06
+                ],
+                [
+                    15.04,
+                    55.06
+                ],
+                [
+                    15.04,
+                    47.27
+                ],
+                [
+                    5.87,
+                    47.27
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "title": "Surface Weather Observations",
+        "description": "Surface Observations measured at the automatic and manual stations of Deutscher Wetterdienst, the German Weather Service",
+        "themes": [
+            {
+                "concepts": [
+                    {
+                        "id": "meteorology"
+                    }
+                ],
+                "scheme": "http://wis.wmo.int/2012/codelists/WMOCodeLists#WMO_CategoryCode"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "weather"
+                    }
+                ],
+                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "de-dwd"
+                    }
+                ],
+                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/centre-id.csv"
+            },
+			{
+                "concepts": [
+                    {
+                        "id": "continual"
+                    }
+                ],
+                "scheme": "https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_FrequencyCode"
+            }
+        ],
+               "contacts": [
+            {
+                "name": "Kai-Thorsten Wirt",
+                "organization": "Deutscher Wetterdienst",
+                "emails": [
+                    {
+                        "value": "wis@dwd.de"
+                    }
+                ],
+                "addresses": [
+                    {
+                        "deliveryPoint": [
+                            "Frankfurter Strasse 135"
+                        ],
+                        "city": "Offenbach",
+                        "postalCode": "63067",
+                        "country": "Germany"
+                    }
+                ],
+                "links": [
+                    {
+                        "type": "text/html",
+                        "href": "https://www.dwd.de/wmc"
+                    },
+                    {
+                        "type": "text/html",
+                        "href": "https://gisc.dwd.de"
+                    }
+                ],
+                "contactInstructions": "email",
+                "roles": [
+                    "host"
+                ]
+            }
+        ],
+        "type": "dataset",
+        "created": "2023-11-01",
+        "updated": "2023-11-01",
+        "wmo:dataPolicy": "core"
+    },
+    "links": [
+        {
+            "rel": "http://def.wmo.int/def/rel/wmdr/-/FacilitySet",
+            "href": "https://oscar.wmo.int/surface/rest/api/search/station/?&operatingStatus=Operational&territoryName=DEU&longitudeMin=5.87&longitudeMax=15.04&latitudeMax=55.06&latitudeMin=47.27",
+            "type": "application/json",
+            "title": "Stations associated with this dataset"
+        },
+        {
+            "rel": "data",
+            "href": "https://opendata.dwd.de/weather/weather_reports/synoptic/germany/Z__C_EDZW_latest_bda01%2Csynop_bufr_GER_999999_999999__MW_XXX.bin",
+            "type": "application/octet-stream",
+            "title": "Raw data download (BUFR)"
+        }
+    ]
+}

--- a/examples/de-dwd.surface-weather-observations-realtime.json
+++ b/examples/de-dwd.surface-weather-observations-realtime.json
@@ -57,15 +57,7 @@
                 ],
                 "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv"
             },
-            {
-                "concepts": [
-                    {
-                        "id": "de-dwd"
-                    }
-                ],
-                "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/centre-id.csv"
-            },
-			{
+	    {
                 "concepts": [
                     {
                         "id": "continual"
@@ -126,6 +118,13 @@
             "href": "https://opendata.dwd.de/weather/weather_reports/synoptic/germany/Z__C_EDZW_latest_bda01%2Csynop_bufr_GER_999999_999999__MW_XXX.bin",
             "type": "application/octet-stream",
             "title": "Raw data download (BUFR)"
+        },
+	{
+            "rel": "items",
+            "channel": "origin/a/wis2/de-dwd/data/core/weather/surface-based-observations/synop",
+            "href": "mqtts://everyone:everyone@wis2.dwd.de:8883",
+            "type": "application/json",
+            "title": "Data notifications"
         }
     ]
 }


### PR DESCRIPTION
We have updated our examples and created a new one for observations from Germany with a link to Oscar.
We noticed the following when updating our examples:
- time-Section:
  - interval does not accept durations
  - interval does not accept multiple arrays
  - time: null is not accepted

- WTH themes/concept
  - metadata without any block for "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/..." are valid and even grade "A"
  - metadata should include the most specific csv as scheme-link (inside domain-specific)
  - centre-id.csv should always be included in concepts
  - we need a service to create a full WTH value out of metadata record

- additionalExtents.temporal 
  - does not accept more than one block (example icon-eps different resolutions for different forecast ranges)

- ets validation
  - response for not valid JSON as response/result included? 