### PR TITLE
Fix simple errors in snippets

### DIFF
--- a/standard/recommendations/core/REC_data_policy.adoc
+++ b/standard/recommendations/core/REC_data_policy.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/data_policy_conditions*
-^|A | Additional conditions represented by a `+links+` item SHOULD also provide a `title` property to include human-readable information about link.
+^|A | Additional conditions represented by a `+links+` item SHOULD also provide a `title` property to include human-readable information about the link.
 |===

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -321,22 +321,22 @@ extents provide a useful indicator of the location of the dataset to facilitate 
 [source,json]
 ----
 "geometry": {
-    "type": "Polygon",
-    "coordinates": [[
-            [-142.23, 28.03],
-            [-142.23, 82.56],
-            [-52.16, 82.56],
-            [-52.16, 28.03],
-            [-142.23, 28.03]
-    ]]
+  "type": "Polygon",
+  "coordinates": [[
+    [-142.23, 28.03],
+    [-142.23, 82.56],
+    [-52.16, 82.56],
+    [-52.16, 28.03],
+    [-142.23, 28.03]
+  ]]
 }
 ----
 
 [source,json]
 ----
 "geometry": {
-    "type": "Point",
-    "coordinates": [-79.38, 43.65]
+  "type": "Point",
+  "coordinates": [-79.38, 43.65]
 }
 ----
 
@@ -453,26 +453,26 @@ Further time-related characteristics (e.g. frequency of modifications, available
 [source,json]
 ----
 "time": {
-    "interval": [
-        ["T00Z", "PT180H"],
-        ["T12Z", "PT180H"]
-    ],
-    "resolution": "PT6H"
+  "interval": [
+    ["T00Z", "PT180H"],
+    ["T12Z", "PT180H"]
+  ],
+  "resolution": "PT6H"
 },
 "properties": {
+  ...
+  "description": "[...] up to +180h every 6h, runs 00/12 UTC [...]."
+  ...
+  "themes": [
+    {
+      "concepts": [
+        {"id": "continual"}
+      ],
+      "scheme": "https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_FrequencyCode"
+    }
     ...
-    "description": "[...] up to +180h every 6h, runs 00/12 UTC [...]."
-    ...
-    "themes": [
-        {
-        "concepts": [
-            {"id": "continual"}
-        ],
-        "scheme": "https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_FrequencyCode"
-        }
-        ...
-    ]
-    ...
+  ]
+  ...
 }
 ----
 
@@ -519,29 +519,29 @@ The `+contacts+` property is the information associated with one or more respons
 "properties": {
   ...
   "contacts": [{
-      "identifier": "ECCC",
-      "organization": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
-      "positionName": "National Inquiry Response Team",
-      "phones": [{
-        "value": "+18199972800"
-      }],
-      "emails": [{
-        "value":"enviroinfo@ec.gc.ca"
-      }],
-      "addresses": [{
-        "deliveryPoint": [ "77 Westmorland Street, suite 260" ],
-        "city": "Fredericton",
-        "administrativeArea": "NB",
-        "postalCode": "E3B 6Z4",
-        "country": "Canada"
-      }],
-      "links": [{
-        "href": "https://www.canada.ca/en/environment-climate-change.html",
-        "rel": "canonical",
-        "type": "text/html"
-      }],
-      "contactInstructions": "email",
-      "roles": ["producer", "host"]
+    "identifier": "ECCC",
+    "organization": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
+    "positionName": "National Inquiry Response Team",
+    "phones": [{
+      "value": "+18199972800"
+    }],
+    "emails": [{
+      "value":"enviroinfo@ec.gc.ca"
+    }],
+    "addresses": [{
+      "deliveryPoint": [ "77 Westmorland Street, suite 260" ],
+      "city": "Fredericton",
+      "administrativeArea": "NB",
+      "postalCode": "E3B 6Z4",
+      "country": "Canada"
+    }],
+    "links": [{
+      "href": "https://www.canada.ca/en/environment-climate-change.html",
+      "rel": "canonical",
+      "type": "text/html"
+    }],
+    "contactInstructions": "email",
+    "roles": ["producer", "host"]
   }]
   ...
 }
@@ -612,7 +612,7 @@ Examples of persistent identifiers include, but are not limited to:
   }, {
     "scheme": "ark",
     "value": "ark:/13030/tf5p30086k"
-  } ]
+  }]
   ...
 }
 ----

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -716,22 +716,6 @@ Licensing and copyright are expressed via the links property (see distribution s
 }
 ----
 
-.Example: Recommended Data with additional conditions
-[source,json]
-----
-"properties": {
-  ...
-  "wmo:dataPolicy": "recommended"
-  ...
-},
-"links": [{
-  "rel": "license",
-  "href": "https://example.org/dataset/license.html",
-  "type": "text/html",
-  "title": "Dataset license information"
-}]
-----
-
 It is useful to add provider-specific details to have the most detailed information about data policy and additional conditions.
 
 include::../recommendations/core/REC_data_policy.adoc[]
@@ -982,13 +966,15 @@ Additional distribution information is added to allow more comprehensive discove
       "numberOfFiles": "288 per day",
       "typicalFilesize": "60 MB",
       "typicalFilename": "MSG3-SEVI-MSG15-0100-NA-20130208102743.243000000Z-1051616.zip",
-      "samples": "https://data.eumetsat.int/data/access/MSG3-SEVI-MSG15-0100-NA-20130208102743.243000000Z-1051616.zip",
-      "documentation": {
+      "samples": { 
+        "href": "https://data.eumetsat.int/data/access/MSG3-SEVI-MSG15-0100-NA-20130208102743.243000000Z-1051616.zip" 
+      },
+      "documentation": [{
         "rel": "alternate",
         "type": "text/html",
         "title": "SIP documentation and tools",
         "href": "https://www.eumetsat.int/formats#SIP"
-      }
+      }]
     }]
   }
 }]

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -529,14 +529,16 @@ The `+contacts+` property is the information associated with one or more respons
         "value":"enviroinfo@ec.gc.ca"
       }],
       "addresses": [{
-        "deliveryPoint": "77 Westmorland Street, suite 260",
+        "deliveryPoint": [ "77 Westmorland Street, suite 260" ],
         "city": "Fredericton",
         "administrativeArea": "NB",
         "postalCode": "E3B 6Z4",
         "country": "Canada"
       }],
       "links": [{
-        "href": "https://www.canada.ca/en/environment-climate-change.html"
+        "href": "https://www.canada.ca/en/environment-climate-change.html",
+        "rel": "canonical",
+        "type": "text/html"
       }],
       "contactInstructions": "email",
       "roles": ["producer", "host"]

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -554,11 +554,14 @@ Note that a contact can also be specified by using a URL:
 "properties": {
   ...
   "contacts": [{
-      "name": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
-      "links": [{
-          "href": "https://www.canada.ca/en/environment-climate-change/corporate/contact.html"
-      }]
-  ]
+    "organization": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
+    "links": [{
+      "href": "https://www.canada.ca/en/environment-climate-change/corporate/contact.html",
+      "rel": "canonical",
+      "type": "text/html"
+    }],
+    "roles": ["producer"]
+  }]
   ...
 }
 ----


### PR DESCRIPTION
In addition, normalized indentation to two spaces. Some snippets were originally indented with four spaces.