### PR TITLE
Check examples consistency

### DIFF
--- a/examples/ca-eccc-msc-gdc.global-discovery-catalogue.json
+++ b/examples/ca-eccc-msc-gdc.global-discovery-catalogue.json
@@ -125,38 +125,10 @@
     },
     "links": [
         {
-            "rel": "data",
-            "type": "text/html",
-            "title": "WMO WIS Global Cache - Deutscher Wetterdienst (Cached files < 24h during pilot)",
-            "href": "https://opendata.dwd.de/test/wis2/cache"
-        },
-        {
             "rel": "archives",
             "type": "text/html",
             "title": "Open Data Server DWD (Metadata Archive)",
             "href": "https://opendata.dwd.de/test/wis2/cache_metadata"
-        },
-        {
-            "rel": "related",
-            "type": "application/json",
-            "title": "WMO WIS2 Global Broker - M\u00e9t\u00e9o-France",
-            "href": "mqtts://everyone:everyone@globalbroker.meteo.fr:8883",
-            "channel": "cache/a/wis2/#",
-            "distribution": {
-                "maxMSGsize": 4096,
-                "unit": "bytes"
-            }
-        },
-        {
-            "rel": "related",
-            "type": "application/json",
-            "title": "WMO WIS Global Broker - China Meteorological Administration",
-            "href": "mqtt://everyone:everyone@gb.wis.cma.cn:1883",
-            "channel": "cache/a/wis2/#",
-            "distribution": {
-                "maxMSGsize": 4096,
-                "unit": "bytes"
-            }
         }
     ]
 }

--- a/examples/ca-eccc-msc-gdc.global-discovery-catalogue.json
+++ b/examples/ca-eccc-msc-gdc.global-discovery-catalogue.json
@@ -77,7 +77,7 @@
                         "title": "Global Discovery Catalogue"
                     }
                 ],
-                "scheme": "https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/service-types.csv"
+                "scheme": "https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/global-service-type.csv"
             }
         ],
         "contacts": [

--- a/examples/ca-eccc-msc-gdc.global-discovery-catalogue.json
+++ b/examples/ca-eccc-msc-gdc.global-discovery-catalogue.json
@@ -106,7 +106,7 @@
                 ],
                 "links": [
                     {
-                        "rel": "canonical",
+                        "rel": "about",
                         "type": "text/html",
                         "href": "https://www.canada.ca/en/environment-climate-change.html"
                     }

--- a/examples/ca-eccc-msc.surface-weather-observations-realtime.json
+++ b/examples/ca-eccc-msc.surface-weather-observations-realtime.json
@@ -151,7 +151,7 @@
         {
             "rel": "items",
             "href": "mqtts://example.org",
-            "channel": "origin/a/wis2/ca-eccc-msc/data/core/weather/observations/surface-land/landFixed",
+            "channel": "origin/a/wis2/ca-eccc-msc/data/core/weather/surface-based-observations/synop",
             "type": "application/json",
             "title": "Data notifications"
         }

--- a/examples/ca-eccc-msc.surface-weather-observations-realtime.json
+++ b/examples/ca-eccc-msc.surface-weather-observations-realtime.json
@@ -143,7 +143,7 @@
             "title": "Data access API interface"
         },
         {
-            "rel": "related",
+            "rel": "about",
             "href": "https://eccc-msc.github.io/open-data/msc-data/obs_station/readme_obs_insitu_swobdatamart_en",
             "type": "text/html",
             "title": "Documentation"

--- a/examples/ca-eccc-msc.surface-weather-observations-realtime.json
+++ b/examples/ca-eccc-msc.surface-weather-observations-realtime.json
@@ -106,7 +106,7 @@
                 ],
                 "links": [
                     {
-                        "rel": "canonical",
+                        "rel": "about",
                         "type": "text/html",
                         "href": "https://www.canada.ca/en/environment-climate-change.html"
                     }

--- a/examples/cn-cma-nmic.prediction-forecast.json
+++ b/examples/cn-cma-nmic.prediction-forecast.json
@@ -144,7 +144,7 @@
         },
         {
             "rel": "items",
-            "channel": "cache/a/wis2/#",
+            "channel": "origin/a/wis2/cn-cma-babj/weather/prediction/forecast/#",
             "type": "application/json",
             "title": "Data notifications - WMO WIS Global Broker - CMA",
             "href": "mqtt://everyone:everyone@gb.wis.cma.cn:1883"

--- a/examples/cn-cma-nmic.prediction-forecast.json
+++ b/examples/cn-cma-nmic.prediction-forecast.json
@@ -146,13 +146,6 @@
             "rel": "items",
             "channel": "cache/a/wis2/#",
             "type": "application/json",
-            "title": "Data notifications - WMO WIS2 Global Broker - MF",
-            "href": "mqtts://everyone:everyone@globalbroker.meteo.fr:8883"
-        },
-        {
-            "rel": "items",
-            "channel": "cache/a/wis2/#",
-            "type": "application/json",
             "title": "Data notifications - WMO WIS Global Broker - CMA",
             "href": "mqtt://everyone:everyone@gb.wis.cma.cn:1883"
         }

--- a/examples/cn-cma-nmic.surface-based-observations.json
+++ b/examples/cn-cma-nmic.surface-based-observations.json
@@ -50,20 +50,11 @@
                     }
                 ],
                 "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/weather/index.csv"
-            },
-            {
-                "concepts": [
-                    {
-                        "id": "global-broker",
-                        "title": "Global Broker"
-                    }
-                ],
-                "scheme": "https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/global-service-type.csv"
             }
         ],
         "contacts": [
             {
-                "name": "GISC Beijing",
+                "name": "GISC Beijing Team",
                 "organization": "China Meteorological Administration (CMA); National Meteorological Information Center (NMIC)",
                 "phones": [
                     {
@@ -117,13 +108,6 @@
             "type": "text/html",
             "title": "Raw data download (bufr4)",
             "href": "https://wisdev.kishou.go.jp/data/wis2/chn/babj/data/core/weather/surface-based-observations/synop/"
-        },
-        {
-            "rel": "items",
-            "channel": "cache/a/wis2/#",
-            "type": "application/json",
-            "title": "Data notifications - WMO WIS2 Global Broker - MF",
-            "href": "mqtts://everyone:everyone@globalbroker.meteo.fr:8883"
         },
         {
             "rel": "items",

--- a/examples/de-dwd.global-cache.json
+++ b/examples/de-dwd.global-cache.json
@@ -138,14 +138,7 @@
         "keywords": [
             "WIS2",
             "Global Cache"
-        ],
-        "externalIds": [
-            {
-                "scheme": "DWD",
-                "value": "de.dwd.globalcache"
-            }
-        ],
-        "language": "eng"
+        ]
     },
     "links": [
         {

--- a/examples/de-dwd.global-cache.json
+++ b/examples/de-dwd.global-cache.json
@@ -4,12 +4,7 @@
     "conformsTo": [
         "http://wis.wmo.int/spec/wcmp/2/conf/core"
     ],
-    "time": {
-        "interval": [
-            "2024-01-01T00:00:00Z",
-            ".."
-        ]
-    },
+    "time": null,
     "geometry": {
         "type": "Polygon",
         "coordinates": [

--- a/examples/fr-meteo-france.global-broker.json
+++ b/examples/fr-meteo-france.global-broker.json
@@ -122,19 +122,7 @@
     },
     "links": [
         {
-            "rel": "data",
-            "type": "text/html",
-            "title": "WMO WIS Global Cache - Deutscher Wetterdienst (Cached files < 24h during pilot)",
-            "href": "https://opendata.dwd.de/test/wis2/cache"
-        },
-        {
-            "rel": "archives",
-            "type": "text/html",
-            "title": "Open Data Server DWD (Metadata Archive)",
-            "href": "https://opendata.dwd.de/test/wis2/cache_metadata"
-        },
-        {
-            "rel": "related",
+            "rel": "items",
             "type": "application/json",
             "title": "WMO WIS2 Global Broker - M\u00e9t\u00e9o-France",
             "href": "mqtts://everyone:everyone@globalbroker.meteo.fr:8883",

--- a/examples/fr-meteo-france.global-broker.json
+++ b/examples/fr-meteo-france.global-broker.json
@@ -77,7 +77,7 @@
                         "title": "Global Broker"
                     }
                 ],
-                "scheme": "https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/service-types.csv"
+                "scheme": "https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/global-service-type.csv"
             }
         ],
         "contacts": [

--- a/examples/us-noaa-nws.gfs-10deg.json
+++ b/examples/us-noaa-nws.gfs-10deg.json
@@ -41,6 +41,7 @@
         "created": "2022-06-23T18:36:00Z",
         "updated": "2022-06-23T18:36:00Z",
         "wmo:dataPolicy": "core",
+        "rights": "access",
         "type": "dataset",
         "title": "Global Forecast System 1 Degree Resolution",
         "description": "The Global Forecast System is a weather forecast model produced by the National Centers for Environmental Prediction.",
@@ -302,9 +303,7 @@
                     "producer"
                 ]
             }
-        ],
-        "wmo:dataPolicy": "recommended",
-        "rights": "access"
+        ]
     },
     "links": [
         {

--- a/examples/us-noaa-nws.gfs-10deg.json
+++ b/examples/us-noaa-nws.gfs-10deg.json
@@ -50,13 +50,10 @@
             "Tropopause",
             "Atmospheric Pressure Measurements",
             "Pressure Thickness",
-            "Sea Level Pressure",
             "Surface Pressure",
             "Land Cover",
             "Soil Moisture/Water Content",
-            "Soil Temperature",
             "Sea Surface Temperature",
-            "Albedo",
             "Incoming Solar Radiation",
             "Longwave Radiation",
             "Outgoing Longwave Radiation",
@@ -66,7 +63,6 @@
             "Atmospheric Stability",
             "Boundary Layer Temperature",
             "Dew Point Temperature",
-            "Surface Temperature",
             "Upper Air Temperature",
             "Water Vapor Processes",
             "Water Vapor Indicators",
@@ -81,8 +77,6 @@
             "Precipitation Rate",
             "Liquid Precipitation",
             "Solid Precipitation",
-            "Snow Cover",
-            "Snow Depth",
             "Sea Ice Concentration",
             "Land Use/Land Cover Classification",
             "Prediction",
@@ -122,8 +116,6 @@
             "middle_cloud_layer",
             "middle_cloud_top_level",
             "nominal_top_of_the_atmosphere",
-            "absolute_vorticity",
-            "albedo",
             "apparent_temperature",
             "best_(4_layer)_lifted_index",
             "categorical_freezing_rain_(yes=1;_no=0)",
@@ -200,13 +192,8 @@
             "u-component_storm_motion",
             "upward_long-wave_radiation_flux",
             "upward_short-wave_radiation_flux",
-            "v-component_of_wind",
-            "v-component_storm_motion",
-            "vegetation",
             "ventilation_rate",
             "vertical_speed_shear",
-            "vertical_velocity_(geometric)",
-            "vertical_velocity_(pressure)",
             "visibility",
             "volumetric_soil_moisture_content",
             "water_equivalent_of_accumulated_snow_depth",
@@ -220,7 +207,6 @@
             "weatherForecasts",
             "meteorology"
         ],
-        "keywordsCodespace": "http://codes.wmo.int/306/4678",
         "language": "en",
         "themes": [
             {
@@ -230,6 +216,52 @@
                     }
                 ],
                 "scheme": "https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "TODO - find a keyword matching old keywordsCodespace"
+                    }
+                ],
+                "scheme": "http://codes.wmo.int/306/4678"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "Absolute vorticity"
+                    },
+                    {
+                        "id": "Albedo"
+                    },
+                    {
+                        "id": "Pressure reduced to MSL"
+                    },
+                    {
+                        "id": "Snow cover"
+                    },
+                    {
+                        "id": "Snow depth"
+                    },
+                    {
+                        "id": "Soil temperature"
+                    },
+                    {
+                        "id": "v-component of wind"
+                    },
+                    {
+                        "id": "v-component storm motion"
+                    },
+                    {
+                        "id": "Vegetation"
+                    },
+                    {
+                        "id":"Vertical velocity (geometric))"
+                    },
+                    {
+                        "id":"Vertical velocity (pressure)"
+                    }
+                ],
+                "scheme": "https://codes.wmo.int/grib2/codeflag/_4.2"
             }
         ],
         "contacts": [
@@ -258,9 +290,10 @@
                 ],
                 "links": [
                     {
-                        "href": "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/",
-                        "rel": "canonical",
-                        "type": "text/html"
+                        "href": "https://nomads.ncep.noaa.gov/info.php?page=documents",
+                        "rel": "about",
+                        "type": "text/html",
+                        "title": "NOMADS Documents"
                     }
                 ],
                 "contactInstructions": "email",
@@ -270,10 +303,7 @@
                 ]
             }
         ],
-        "formats": [
-            "GRIB2"
-        ],
-        "license": "http://codes.wmo.int/wmdr/DataPolicy/_WMOOther",
+        "wmo:dataPolicy": "recommended",
         "rights": "access"
     },
     "links": [


### PR DESCRIPTION
I tried to group the examples and then compared them within the group...

1) observations
- ca-eccc-msc.surface-weather-observations-realtime.json
- cn-cma-nmic.surface-based-observations.json
- de-dwd.surface-weather-observations-realtime.json

Open questions:
- Should under links.href for data notifications as value not be own MQTT broker address or may placeholder like "mqtts://example.org" be used here?

2) Global Services
- ca-eccc-msc-gdc.global-discovery-catalogue.json
- fr-meteo-france.global-broker.json
- de-dwd.global-cache.json

3) NWP
- ca-eccc-msc.cmip5-tt.json
- ca-eccc-msc.nwp-gdps.json
- cn-cma-nmic.prediction-forecast.json
- de-dwd.icon-eps-all.json
- us-noaa-nws.gfs-10deg.json

4) Hydrology
- ca-eccc-msc.hydrometric-archive.json (--> "mqtts://example.org" ok?)
- ca-eccc-msc.hydrometric-realtime.json (--> "mqtts://example.org" ok?)

5) Satellite
- us-noaa-nws.goes16-satellite-sst.json
- int-eumetsat-serviri-core.json

6) Climate
- ca-eccc-msc.daily-climate-observations.json (--> "mqtts://example.org" ok?)

5 TODO

All changes are only proposals and need further reviews/discussion...