### PR TITLE
delineate conformance classes from requirements classes

### DIFF
--- a/standard/requirements/requirements_class_core.adoc
+++ b/standard/requirements/requirements_class_core.adoc
@@ -2,7 +2,7 @@
 [cols="1,4",width="90%"]
 |===
 2+|*Requirements Class*
-2+|http://wis.wmo.int/spec/wcmp/2/conf/core
+2+|http://wis.wmo.int/spec/wcmp/2/req/core
 |Target type |Discovery Metadata
 |Dependency |<<rfc8259,IETF RFC 8259: The JavaScript Object Notation (JSON) Data Interchange Format>>
 |Dependency |<<json-schema, JSON Schema>>

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -2,11 +2,11 @@
 
 A WCMP record provides descriptive information about a dataset made available through WIS2.
 
-=== Conformance Class "Core"
+=== Requirements Class "Core"
 
 ==== Overview
 
-The WCMP Core Conformance Class provides requirements for a WCMP discovery metadata record.
+The WCMP Core Requirements Class provides requirements for a WCMP discovery metadata record.
 
 include::../requirements/requirements_class_core.adoc[]
 


### PR DESCRIPTION
Editorial updates based on clarifications after reviewing OGC ModSpec.

- Requirements classes are put forth as 1..n requirements (per clauses in main document)
- Conformance classes are part of the ATS proper