### PR TITLE
Emphasize that WCMP2 is GeoJSON #190

### DIFF
--- a/examples/ca-eccc-msc.daily-climate-observations.json
+++ b/examples/ca-eccc-msc.daily-climate-observations.json
@@ -147,7 +147,7 @@
             "rel": "items",
             "href": "mqtts://example.org",
             "channel": "origin/a/wis2/ca-eccc-msc/data/core/climate/observations",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         }
     ]

--- a/examples/ca-eccc-msc.hydrometric-archive.json
+++ b/examples/ca-eccc-msc.hydrometric-archive.json
@@ -152,7 +152,7 @@
             "rel": "items",
             "href": "mqtts://example.org",
             "channel": "origin/a/wis2/ca-eccc-msc/data/core/hydrology",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         },
         {

--- a/examples/ca-eccc-msc.hydrometric-realtime.json
+++ b/examples/ca-eccc-msc.hydrometric-realtime.json
@@ -147,7 +147,7 @@
             "rel": "items",
             "href": "mqtts://example.org",
             "channel": "origin/a/wis2/ca-eccc-msc/data/core/hydrology",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         },
         {

--- a/examples/ca-eccc-msc.nwp-gdps.json
+++ b/examples/ca-eccc-msc.nwp-gdps.json
@@ -143,7 +143,7 @@
             "rel": "items",
             "channel": "origin/a/wis2/ca-eccc-msc/data/core/weather/nwp/global",
             "href": "mqtts://example.org",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         }
     ]

--- a/examples/ca-eccc-msc.surface-weather-observations-realtime.json
+++ b/examples/ca-eccc-msc.surface-weather-observations-realtime.json
@@ -154,7 +154,7 @@
             "rel": "items",
             "href": "mqtts://example.org",
             "channel": "origin/a/wis2/ca-eccc-msc/data/core/weather/surface-based-observations/synop",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         }
     ]

--- a/examples/cn-cma-babj.nmic.prediction-forecast.json
+++ b/examples/cn-cma-babj.nmic.prediction-forecast.json
@@ -145,7 +145,7 @@
         {
             "rel": "items",
             "channel": "origin/a/wis2/cn-cma-babj/weather/prediction/forecast/#",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications - WMO WIS Global Broker - CMA",
             "href": "mqtts://everyone:everyone@example.org:8883"
         }

--- a/examples/cn-cma-babj.nmic.surface-based-observations.json
+++ b/examples/cn-cma-babj.nmic.surface-based-observations.json
@@ -112,7 +112,7 @@
         {
             "rel": "items",
             "channel": "cache/a/wis2/#",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications - WMO WIS Global Broker - CMA",
             "href": "mqtts://everyone:everyone@example.org:8883"
         }

--- a/examples/de-dwd.global-cache.json
+++ b/examples/de-dwd.global-cache.json
@@ -167,7 +167,7 @@
             "rel": "items",
             "channel": "cache/a/wis2",
             "href": "mqtts://everyone:everyone@example.org:8883",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         }
     ]

--- a/examples/de-dwd.icon-eps-all.json
+++ b/examples/de-dwd.icon-eps-all.json
@@ -199,7 +199,7 @@
             "rel": "items",
             "channel": "origin/a/wis2/de-dwd/data/core/weather/prediction/forecast/medium-range",
             "href": "mqtts://everyone:everyone@example.org:8883",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         }
     ]

--- a/examples/de-dwd.surface-weather-observations-realtime.json
+++ b/examples/de-dwd.surface-weather-observations-realtime.json
@@ -127,7 +127,7 @@
             "rel": "items",
             "channel": "origin/a/wis2/de-dwd/data/core/weather/surface-based-observations/synop",
             "href": "mqtts://everyone:everyone@example.org:8883",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         }
     ]

--- a/examples/fr-meteo-france.global-broker.json
+++ b/examples/fr-meteo-france.global-broker.json
@@ -131,7 +131,7 @@
     "links": [
         {
             "rel": "items",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "WMO WIS2 Global Broker - M\u00e9t\u00e9o-France",
             "href": "mqtts://everyone:everyone@example.org:8883",
             "channel": "cache/a/wis2/#",

--- a/examples/int-eumetsat-serviri-core.json
+++ b/examples/int-eumetsat-serviri-core.json
@@ -136,7 +136,7 @@
             "rel": "items",
             "channel": "origin/a/wis2/int-eumetsat/data/core/weather/space-based-observations/satellite4nowcasting/Meteosat-10/ImageL1-5",
             "href": "mqtts://example.org",
-            "type": "application/json",
+            "type": "application/geo+json",
             "title": "Data notifications"
         },
         {

--- a/kpi/core/links-health.adoc
+++ b/kpi/core/links-health.adoc
@@ -43,7 +43,7 @@ Ensure that all links resolve and are accessible via HTTPS.
   "links": [
     {
       "rel": "related",
-      "type": "application/json",
+      "type": "application/geo+json",
       "title": "Global Broker (Toulouse)",
       "href": "mqtts://[yourAccount]:[yourPassword]@globalbroker.meteo.fr:8883/",
       "channel": "cache/a/wis2/#",
@@ -59,7 +59,7 @@ Ensure that all links resolve and are accessible via HTTPS.
   "links": [
     {
       "rel": "subscribe",
-      "type": "application/json",
+      "type": "application/geo+json",
       "title": "Global Broker (Toulouse)",
       "href": "mqtts://[yourAccount]:[yourPassword]@wis2.dwd.de:8883/",
       "channel": "cache/a/wis2/deu/dwd/data/core/weather/analysis-prediction/forecast/model/#"

--- a/standard/recommendations/core/REC_media_type.adoc
+++ b/standard/recommendations/core/REC_media_type.adoc
@@ -1,0 +1,6 @@
+[[rec_core_media_type]]
+[width="90%",cols="2,6a"]
+|===
+^|*Recommendation {counter:rec-id}* |*/rec/core/media_type*
+^|A |The media type assigned to a WCMP record, when transported through a protocol that supports it, SHOULD be ``application/geo+json``.
+|===

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -10,7 +10,7 @@ The WCMP Core Requirements Class provides requirements for a WCMP discovery meta
 
 include::../requirements/requirements_class_core.adoc[]
 
-
+When a record is transported through a protocol that is capable of assigning a media type to it, it should be set to ``application/geo+json``.
 The table below provides an overview of the set of properties that may be included in a WCMP record.
 
 
@@ -865,7 +865,7 @@ For recommended data, the ``links`` property may also provide links to services 
   },
   {
     "rel"  : "items",
-    "type" : "application/json",
+    "type" : "application/geo+json",
     "title": "WIS2 notification service",
     "href" : "mqtts://example.org",
     "channel": "cache/a/wis2/ca-eccc-msc/data/core/weather/surface-based-observations"

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -10,7 +10,6 @@ The WCMP Core Requirements Class provides requirements for a WCMP discovery meta
 
 include::../requirements/requirements_class_core.adoc[]
 
-When a record is transported through a protocol that is capable of assigning a media type to it, it should be set to ``application/geo+json``.
 The table below provides an overview of the set of properties that may be included in a WCMP record.
 
 
@@ -111,6 +110,12 @@ The table below provides an overview of the set of properties that may be includ
 |Additional properties as needed (see <<_additional_properties>>)
 
 |===
+
+==== WCMP record representation
+
+WCMP record can be represented in various ways internally, in WIS systems and software tools, but its external representation is GeoJSON.
+
+include::../recommendations/core/REC_media_type.adoc[]
 
 ==== Validation
 


### PR DESCRIPTION
Examples were updated to use `application/geo+json` for WCMP resources and one humble recommendation  was added to the normative text (chapter 7.1.2. WCMP record representation).