### PR TITLE
Update us-noaa-nws.gfs-10deg.json

### DIFF
--- a/examples/us-noaa-nws.gfs-10deg.json
+++ b/examples/us-noaa-nws.gfs-10deg.json
@@ -205,8 +205,7 @@
             "Weather and Climate",
             "International",
             "Atmosphere",
-            "weatherForecasts",
-            "meteorology"
+            "weatherForecasts"
         ],
         "language": "en",
         "themes": [
@@ -221,10 +220,10 @@
             {
                 "concepts": [
                     {
-                        "id": "TODO - find a keyword matching old keywordsCodespace"
+                        "id": "meteorology"
                     }
                 ],
-                "scheme": "http://codes.wmo.int/306/4678"
+                "scheme": "http://wis.wmo.int/2012/codelists/WMOCodeLists#WMO_CategoryCode"
             },
             {
                 "concepts": [


### PR DESCRIPTION
to remove "toDo" from example

In fact, the keyword list should be reduced and replaced with themes.scheme_concepts where possible, but it is important to at least delete "toDo"