### PR TITLE
 remove Python 3.8/3.9 from CI

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2


### PR DESCRIPTION
This PR updates Python versions in CI (no impact on specification).