### PR TITLE
remove keywordsCodespace from EUMETSAT example

### DIFF
--- a/examples/int-eumetsat-serviri-core.json
+++ b/examples/int-eumetsat-serviri-core.json
@@ -54,7 +54,6 @@
             "land",
             "ocean"
         ],
-        "keywordsCodespace": "http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode",
         "language": {
             "code": "en"
         },


### PR DESCRIPTION
This PR removes `properties.keywordsCodespace` from the EUMETSAT example, since `properties.keywordsCodespace` is not part of WCMP2 and/or OGC API - Records proper.