### PR TITLE
add specification reference to KPIs, remove title presence

### DIFF
--- a/kpi/core/contacts.adoc
+++ b/kpi/core/contacts.adoc
@@ -9,6 +9,10 @@ Metadata records should contain information regarding the contact with the role 
 * `properties.contacts[?(@.roles=="host")].contactInstructions`
 * `properties.contacts[?(@.roles=="publisher")]`
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_12_properties_contacts[Specification reference]
+
 ==== Rationale for measurement
 
 Information about the host allows the user to contact the host in case of anything related to accessing the data.

--- a/kpi/core/contacts.adoc
+++ b/kpi/core/contacts.adoc
@@ -2,16 +2,16 @@
 
 Metadata records should contain information regarding the contact with the role `host` and how to reach them via email, as well as the role `publisher` for citation purposes.
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_12_properties_contacts[Properties / Contacts]
+
 ==== WCMP properties
 
 * `properties.contacts[?(@.roles=="host")]`
 * `properties.contacts[?(@.roles=="host")].emails`
 * `properties.contacts[?(@.roles=="host")].contactInstructions`
 * `properties.contacts[?(@.roles=="publisher")]`
-
-==== WCMP reference
-
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_12_properties_contacts[Specification reference]
 
 ==== Rationale for measurement
 

--- a/kpi/core/description.adoc
+++ b/kpi/core/description.adoc
@@ -4,6 +4,10 @@
 
 * `properties.description`
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_8_properties_description[Specification reference]
+
 ==== Rationale for measurement
 
 The description facilitates understanding and discovery and is a key element of metadata information displayed in search results. Extensive and meaningful descriptive information enables users to both understand and properly evaluate a metadata record and its respective resource in support of data access, visualization and exploitation.

--- a/kpi/core/description.adoc
+++ b/kpi/core/description.adoc
@@ -1,12 +1,12 @@
 === Good quality description
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_8_properties_description[Properties / Description]
+
 ==== WCMP properties
 
 * `properties.description`
-
-==== WCMP reference
-
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_8_properties_description[Specification reference]
 
 ==== Rationale for measurement
 

--- a/kpi/core/graphic-overview.adoc
+++ b/kpi/core/graphic-overview.adoc
@@ -4,6 +4,10 @@
 
 * `$.links[?(@.rel=="preview")]`
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_19_links_and_distribution_information[Specification reference]
+
 ==== Rationale for measurement
 
 A graphic overview of the product provides the user with a high-level preview, which can assist with the initial assessment or evaluation as part of search results presentation.

--- a/kpi/core/graphic-overview.adoc
+++ b/kpi/core/graphic-overview.adoc
@@ -1,17 +1,16 @@
 === Graphic overview for metadata records
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_19_links_and_distribution_information[Links and distribution information]
+
 ==== WCMP properties
 
 * `$.links[?(@.rel=="preview")]`
 
-==== WCMP reference
-
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_19_links_and_distribution_information[Specification reference]
-
 ==== Rationale for measurement
 
 A graphic overview of the product provides the user with a high-level preview, which can assist with the initial assessment or evaluation as part of search results presentation.
-
 
 ==== Measurement
 

--- a/kpi/core/links-health.adoc
+++ b/kpi/core/links-health.adoc
@@ -1,5 +1,11 @@
 === Links health
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_19_links_and_distribution_information[Links and distribution information]
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_10_properties_themes[Properties / Themes]
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_12_properties_contacts[Properties / Contacts]
+
 ==== WCMP properties
 
 All properties with linked information (URLs).
@@ -8,12 +14,6 @@ All properties with linked information (URLs).
 * `properties.themes[*].concepts[*].url`
 * `properties.themes[*].scheme`
 * `properties.contacts[*].links[*].href`
-
-==== WCMP reference
-
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_19_links_and_distribution_information[Specification reference]
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_10_properties_themes[Specification reference]
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_12_properties_contacts[Specification reference]
 
 ==== Rationale for measurement
 

--- a/kpi/core/links-health.adoc
+++ b/kpi/core/links-health.adoc
@@ -9,6 +9,12 @@ All properties with linked information (URLs).
 * `properties.themes[*].scheme`
 * `properties.contacts[*].links[*].href`
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_19_links_and_distribution_information[Specification reference]
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_10_properties_themes[Specification reference]
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_12_properties_contacts[Specification reference]
+
 ==== Rationale for measurement
 
 Broken links damage the user experience and give users the impression that a website is not maintained (88% of online consumers are less likely to return to a site after a bad experience). In addition, numerous broken links can affect the reputation and rank of your website when indexed by mass market search engines.

--- a/kpi/core/pids.adoc
+++ b/kpi/core/pids.adoc
@@ -1,12 +1,12 @@
 === Persistent identifiers
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_14_properties_persistent_identifiers[Properties / Persistent identifiers]
+
 ==== WCMP properties
 
 * `properties.externalIds`
-
-==== WCMP properties
-
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_14_properties_persistent_identifiers[Specification reference]
 
 ==== Rationale for measurement
 

--- a/kpi/core/pids.adoc
+++ b/kpi/core/pids.adoc
@@ -4,6 +4,10 @@
 
 * `properties.externalIds`
 
+==== WCMP properties
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_14_properties_persistent_identifiers[Specification reference]
+
 ==== Rationale for measurement
 
 Persistent identifiers allow data to be accessible and citable. They make research data easier to access, reuse and verify, thereby making it easier to build on previous work, conduct new research and avoid duplicating already existing work.

--- a/kpi/core/time-intervals.adoc
+++ b/kpi/core/time-intervals.adoc
@@ -5,6 +5,10 @@
 * `time.interval`
 * `additionalElements.temporal.interval`
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_11_geospatial_and_temporal_extents[Specification reference]
+
 ==== Rationale for measurement
 
 Temporal information is a significant characteristic of weather, climate, and water data and is critical for users to know which time periods are covered by products and how often new products are received.

--- a/kpi/core/time-intervals.adoc
+++ b/kpi/core/time-intervals.adoc
@@ -1,13 +1,13 @@
 === Time intervals
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_11_geospatial_and_temporal_extents[Geospatial and temporal extents]
+
 ==== WCMP properties
 
 * `time.interval`
 * `additionalElements.temporal.interval`
-
-==== WCMP reference
-
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_11_geospatial_and_temporal_extents[Specification reference]
 
 ==== Rationale for measurement
 

--- a/kpi/core/title.adoc
+++ b/kpi/core/title.adoc
@@ -1,11 +1,12 @@
 === Good quality title
-==== WCMP Properties
-
-* `properties.title`
 
 ==== WCMP reference
 
-* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_7_properties_title[Specification reference]
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_7_properties_title[Properties / Title]
+
+==== WCMP Properties
+
+* `properties.title`
 
 ==== Rationale for measurement
 

--- a/kpi/core/title.adoc
+++ b/kpi/core/title.adoc
@@ -3,6 +3,10 @@
 
 * `properties.title`
 
+==== WCMP reference
+
+* https://wmo-im.github.io/wcmp2/standard/wcmp2-STABLE.html#_1_7_properties_title[Specification reference]
+
 ==== Rationale for measurement
 
 The title is the first element of metadata information displayed and helps with initial identification. Meaningful and relevant information makes it easier for users to understand the resource.
@@ -22,9 +26,6 @@ The title should be as specific as possible. For example, if the product contain
 .Good quality title rules
 |===
 |Rule |Score
-
-|The title is present
-|1
 
 |The title has 3 words or more
 |1
@@ -48,5 +49,5 @@ a|The title _does not_ contain a bulletin header (regular expression: `[A-Z]{4}\
 |1
 |===
 
-*Total possible score: 8 (100%)*
+*Total possible score: 7 (100%)*
 


### PR DESCRIPTION
As discussed at TT-WISMD 2026-06-23:
- add specification reference links to each KPI
- remove `properties.title` presence as a score, given it is required for compliance