### PR TITLE
KPI: normalize Example section headings, add example for title

### DIFF
--- a/kpi/core/contacts.adoc
+++ b/kpi/core/contacts.adoc
@@ -33,7 +33,7 @@ The presence of a publisher role.
 * Specify a contact with a publisher role
 * Use ISO https://www.iso.org/iso-3166-country-codes.html[3166-1 alpha-3] codes to specify the `addresses.country` property.
 
-===== Examples
+==== Examples
 
 ```json
   "properties": {

--- a/kpi/core/description.adoc
+++ b/kpi/core/description.adoc
@@ -55,6 +55,7 @@ Add purpose of data resource where relevant (e.g. for survey data)::
     ...
 }
 ```
+
 ==== Rules
 
 .Good quality description implementation rules

--- a/kpi/core/graphic-overview.adoc
+++ b/kpi/core/graphic-overview.adoc
@@ -25,7 +25,7 @@ Examples of catalogues displaying graphic overviews:
 * https://gisc.dwd.de[GISC DWD]
 * https://navigator.eumetsat.int/search?query=MSG%20RGB[EUMETSAT Product Navigator]
 
-===== Example
+==== Examples
 
 ```json
 {

--- a/kpi/core/links-health.adoc
+++ b/kpi/core/links-health.adoc
@@ -23,7 +23,7 @@ HTTPS is increasingly becoming a requirement for numerous agencies as the sugges
 
 ==== Measurement
 
-The number of broken links in each individual metadata record.  Broken links include links that, when accessed, result in a 4xx or 5xx HTTP error.footnote:[https://httpstatuses.com]
+The number of broken links in each individual metadata record.  Broken links include links that, when accessed, result in a 4xx or 5xx HTTP error.footnote:[https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status]
 
 Also being measured is the use of HTTPS (with a valid SSL certificate) as the link protocol throughout WIS metadata.
 
@@ -31,7 +31,7 @@ Also being measured is the use of HTTPS (with a valid SSL certificate) as the li
 
 Ensure that all links resolve and are accessible via HTTPS.
 
-===== Examples
+==== Examples
 
 ```json
   "links": [

--- a/kpi/core/pids.adoc
+++ b/kpi/core/pids.adoc
@@ -21,7 +21,7 @@ Whether persistent identifier information is available, can be successfully iden
 * Provide a persistent identifier
 * Provide a 'Cite as' template as a link object with `rel="cite-as"`
 
-===== Examples 
+==== Examples
 
 ```json
 "properties": {

--- a/kpi/core/time-intervals.adoc
+++ b/kpi/core/time-intervals.adoc
@@ -21,7 +21,7 @@ The time interval is present and has a corresponding resolution.
 
 A temporal interval and its associated resolution should be expressed for data generated with a given frequency or cadence.  For example, ongoing hourly weather observations express a temporal interval with an "open-ended" end time (represented as `..`) and a `resolution` as an ISO 8601 Duration.
 
-===== Examples
+==== Examples
 
 ```json
 "time": {

--- a/kpi/core/title.adoc
+++ b/kpi/core/title.adoc
@@ -22,6 +22,16 @@ The length is not too short or too long, contains fewer than three acronyms and 
 
 The title should be as specific as possible. For example, if the resource contains only one parameter, this can be stated in the title; however, if the resource contains numerous parameters, a more general term should be used in the title, and the parameters should be stated elsewhere in the metadata record (description, themes, keywords, etc.).
 
+==== Examples
+
+```json
+"properties": {
+    ...
+    "title": "Surface weather observations"
+    ...
+}
+```
+
 ==== Rules
 
 .Good quality title rules


### PR DESCRIPTION
This PR:
- normalizes headings for KPI examples
- adds an example for `properties.title`
- updates reference to HTTP status codes in links health