### PR TITLE
editorial updates

### DIFF
--- a/kpi/README.md
+++ b/kpi/README.md
@@ -39,7 +39,7 @@ find . -name "???.adoc" -exec asciidoc-link-check -p -c asciidoc-link-check-conf
 ## Conventions
 
 - Fixed values to always use:
-  - WCMP2 schema: https://schemas.wmo.int/wcmp/2.0.0/schemas/wcmp2-bundled.json
+  - WCMP2 schema: https://schemas.wmo.int/wcmp/2.3.0/schemas/wcmp2-bundled.json
 - always fence JSON snippets, single element names as code
 
 ## Releasing

--- a/schemas/wcmp2-bundled.json
+++ b/schemas/wcmp2-bundled.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.wmo.int/wcmp/2.1.0/schemas/wcmp2-bundled.json",
+  "$id": "https://schemas.wmo.int/wcmp/2.3.0/schemas/wcmp2-bundled.json",
   "title": "WCMP discovery metadata record definition",
   "description": "WCMP discovery metadata record definition",
   "required": [

--- a/standard/sections/annex_b_schemas.adoc
+++ b/standard/sections/annex_b_schemas.adoc
@@ -3,7 +3,7 @@
 :appendix-caption: Annex
 == Schemas (Normative)
 
-NOTE: The schema document will be published on https://schemas.wmo.int/wcmp/2.0.0 once the standard has been approved.
+NOTE: The schema document will be published on https://schemas.wmo.int/wcmp once the standard has been approved.
 
 === WMO Core Metadata Profile Schema
 

--- a/standard/sections/annex_b_schemas.adoc
+++ b/standard/sections/annex_b_schemas.adoc
@@ -3,7 +3,7 @@
 :appendix-caption: Annex
 == Schemas (Normative)
 
-NOTE: The schema document will be published on http://schemas.wmo.int/wcmp/2.0.0 once the standard has been approved.
+NOTE: The schema document will be published on https://schemas.wmo.int/wcmp/2.0.0 once the standard has been approved.
 
 === WMO Core Metadata Profile Schema
 

--- a/standard/sections/clause_5_conventions.adoc
+++ b/standard/sections/clause_5_conventions.adoc
@@ -12,11 +12,11 @@ All requirements and conformance tests that appear in this document are denoted 
 
 Examples provided in this specification are encoded as GeoJSON.
 
-Complete examples can be found at https://schemas.wmo.int/wcmp/2.0.0/examples
+Complete examples can be found at https://schemas.wmo.int/wcmp/2.3.0/examples
 
 === Schemas
 
-The WCMP schema can be found at https://schemas.wmo.int/wcmp/2.0.0/schemas/wcmp2-bundled.json
+The WCMP schema can be found at https://schemas.wmo.int/wcmp/2.3.0/schemas/wcmp2-bundled.json
 
 === Schema representation
 


### PR DESCRIPTION
- update schemas to use https
- point to WCMP2 2.3.0 in documentation